### PR TITLE
Add more tests for try_convert_to_type

### DIFF
--- a/pytest/unit/iterable_functions/test_try_convert_to_type.py
+++ b/pytest/unit/iterable_functions/test_try_convert_to_type.py
@@ -1,4 +1,5 @@
 import pytest
+from typing import Any
 from iterable_functions.try_convert_to_type import try_convert_to_type
 
 def test_try_convert_to_type_success_int() -> None:
@@ -43,3 +44,46 @@ def test_try_convert_to_type_type_error() -> None:
     """
     with pytest.raises(TypeError):
         try_convert_to_type("123", "not a type")
+
+def test_try_convert_to_type_success_list() -> None:
+    """
+    Test the try_convert_to_type function with list conversion.
+    """
+    value = (1, 2, 3)
+    target_type = list
+    expected_output = [1, 2, 3]
+    assert try_convert_to_type(value, target_type) == expected_output
+
+def test_try_convert_to_type_success_bool() -> None:
+    """
+    Test the try_convert_to_type function with bool conversion.
+    """
+    value = 0
+    target_type = bool
+    expected_output = False
+    assert try_convert_to_type(value, target_type) is expected_output
+
+def test_try_convert_to_type_custom_class() -> None:
+    """
+    Test the try_convert_to_type function with a custom class.
+    """
+    class Custom:
+        def __init__(self, val: Any) -> None:
+            self.val = int(val)
+
+        def __eq__(self, other: object) -> bool:  # pragma: no cover - simple equality
+            return isinstance(other, Custom) and self.val == other.val
+
+    value = "5"
+    target_type = Custom
+    expected_output = Custom(5)
+    assert try_convert_to_type(value, target_type) == expected_output
+
+def test_try_convert_to_type_invalid_list_conversion() -> None:
+    """
+    Test the try_convert_to_type function when conversion to list fails.
+    """
+    value = 1
+    target_type = list
+    with pytest.raises(ValueError):
+        try_convert_to_type(value, target_type)


### PR DESCRIPTION
## Summary
- expand `pytest/unit/iterable_functions/test_try_convert_to_type.py`
  - add import for `Any`
  - include new success cases for list, bool, and a custom class
  - add new failure case for invalid list conversion

## Testing
- `pytest -q` *(fails: 27 failed, 1406 passed)*

------
https://chatgpt.com/codex/tasks/task_e_686bd01eabb08325a3d2d3f87a6702d7