### PR TITLE
Fix sys.path usage in conftest

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,5 +1,5 @@
 import sys
 import os
 
-# Add the directory containing strings_utility.py to the Python path
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../')))
+# Add the project root to the Python path to allow local imports
+sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))


### PR DESCRIPTION
## Summary
- keep tests from polluting `sys.path`

## Testing
- `pytest -q` *(fails: 27 failed, 1406 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6870ff7db76c8325a0e5e0b7a7467d96