### PR TITLE
Fix multiprocessing imports

### DIFF
--- a/multiprocessing_functions/parallel_dynamic_distribute.py
+++ b/multiprocessing_functions/parallel_dynamic_distribute.py
@@ -1,4 +1,4 @@
-from multiprocessing import Pool
+from multiprocessing import Pool, cpu_count
 from typing import Callable, List, TypeVar
 
 # Define type variables for input and output types

--- a/multiprocessing_functions/parallel_pipeline.py
+++ b/multiprocessing_functions/parallel_pipeline.py
@@ -1,4 +1,4 @@
-from multiprocessing import Pool
+from multiprocessing import Pool, cpu_count
 from typing import Callable, List, TypeVar
 
 # Define type variables for input and output types

--- a/multiprocessing_functions/parallel_progress_bar.py
+++ b/multiprocessing_functions/parallel_progress_bar.py
@@ -1,4 +1,4 @@
-from multiprocessing import Pool
+from multiprocessing import Pool, cpu_count
 from typing import Callable, List, TypeVar
 from tqdm import tqdm  # Install using: pip install tqdm
 


### PR DESCRIPTION
## Summary
- import `cpu_count` in more multiprocessing functions to avoid NameError

## Testing
- `bash pytest.sh` *(fails: 27 failed, 1406 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68712dbad4cc832585632d62fcd49ca0