### PR TITLE
Update README with Allure CLI requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ bash pytest.sh
 ```
 
 The script runs tests from `pytest/unit` and stores the report under `pytest_run_tests/`.
+The Allure command-line tool is required to generate the reports. If you don't have it installed, follow the [official installation guide](https://docs.qameta.io/allure/#_installing_a_commandline).
 
 ## Example Usage
 


### PR DESCRIPTION
## Summary
- mention that `pytest.sh` requires the Allure command-line tool
- link to official installation instructions

## Testing
- `pytest -q` *(fails: 27 failed, 1406 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68712dc6f760832598065d61c9a7e02c