### PR TITLE
Fix cache_with_expiration docstring

### DIFF
--- a/decorators/cache_with_expiration.py
+++ b/decorators/cache_with_expiration.py
@@ -18,8 +18,8 @@ def cache_with_expiration(expiration_time: int) -> Callable[[Callable[..., Any]]
     
     Raises
     ------
-    TypeError
-        If the input function is not a positive integer.
+    ValueError
+        If `expiration_time` is not a positive integer.
     """
     if not isinstance(expiration_time, int) or expiration_time < 0:
         raise ValueError("expiration_time must be a positive integer")


### PR DESCRIPTION
## Summary
- fix the `Raises` section for `cache_with_expiration`

## Testing
- `pytest -q` *(fails: 27 failed, 1406 passed)*

------
https://chatgpt.com/codex/tasks/task_e_687298ac60ec8325ac7ba2db70638f03