### PR TITLE
Update serialize_output docstring

### DIFF
--- a/decorators/serialize_output.py
+++ b/decorators/serialize_output.py
@@ -24,7 +24,7 @@ def serialize_output(format: str, logger: logging.Logger = None) -> Callable[[Ca
     ValueError
         If the format is not supported.
     TypeError
-        If logger is not an instance of logging.Logger or
+        If logger is not an instance of logging.Logger or None.
     """
     if not isinstance(logger, logging.Logger) and logger is not None:
         logger = None


### PR DESCRIPTION
## Summary
- update `serialize_output` docstring for logger TypeError message

## Testing
- `pytest -q` *(fails: 27 failed, 1406 passed)*

------
https://chatgpt.com/codex/tasks/task_e_687298acbc6c83259d55feeb0e7a0277