### PR TITLE
Fix timeout decorator docstring

### DIFF
--- a/decorators/timeout.py
+++ b/decorators/timeout.py
@@ -25,7 +25,8 @@ def timeout(seconds: int, logger: Optional[logging.Logger] = None) -> Callable[[
     Raises
     ------
     TypeError
-        If seconds is not an integer or if logger is not an instance of logging.Logger or
+        If ``seconds`` is not an integer or if ``logger`` is not an instance of
+        ``logging.Logger`` or ``None``.
     """
     if not isinstance(logger, logging.Logger) and logger is not None:
         raise TypeError("logger must be an instance of logging.Logger or None")


### PR DESCRIPTION
## Summary
- clarify `timeout` decorator's `Raises` description

## Testing
- `bash pytest.sh` *(fails: 27 failed tests; `allure` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687298acf24483258a8c40af8286debd