### PR TITLE
Fix docstring mismatch in print_message

### DIFF
--- a/print_functions/print_message.py
+++ b/print_functions/print_message.py
@@ -4,26 +4,29 @@ from typing import Optional
 from logger_functions.logger import logger
 
 def print_message(message: str, message_type: str = "info", end = '\n', flush: bool = False) -> None:
-    """
-    Print a formatted message with the current time and message type.
+"""
+Print a formatted message with the current time and message type.
 
-    Parameters
-    ----------
-    message : str
-        The message to print.
-    message_type : str
-        The type of message (e.g., "info", "warning", "error").
-    logger : bool
-        Whether to log the message.
-    end : str
-        The end character to use in the print function.
-    flush : bool
-        Whether to flush the print buffer.
+Parameters
+----------
+message : str
+    The message to print.
+message_type : str
+    The type of message (e.g., "info", "warning", "error").
+end : str
+    The end character to use in the print function.
+flush : bool
+    Whether to flush the print buffer.
 
-    Returns
-    -------
-    None
-    """
+Returns
+-------
+None
+
+Notes
+-----
+Messages are logged through the :data:`logger` object imported from
+``logger_functions.logger``.
+"""
     logger_to_use: Optional[logging.Logger] = logger # This can change to a logger object if user uses --logger
 
     current_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")


### PR DESCRIPTION
## Summary
- correct the `print_message` docstring to match the function signature
- document that logging uses the imported `logger`

## Testing
- `pytest -q` *(fails: 27 failed, 1406 passed)*

------
https://chatgpt.com/codex/tasks/task_e_687298aecfbc832594eac8385d369e53