### PR TITLE
Fix default worker count in multiprocessing helpers

### DIFF
--- a/multiprocessing_functions/parallel_map.py
+++ b/multiprocessing_functions/parallel_map.py
@@ -16,8 +16,9 @@ def parallel_map(func: Callable[[T], R], data: list[T], num_processes: int = Non
     data : List[T]
         The list of data items to process.
     num_processes : int, optional
-        The number of processes to use for parallel execution. If None, it defaults 
-        to the number of available CPUs (by default None).
+        The number of processes to use for parallel execution. If ``None``,
+        it defaults to the number of available CPUs minus one with a minimum
+        of one process.
 
     Returns
     -------
@@ -33,7 +34,8 @@ def parallel_map(func: Callable[[T], R], data: list[T], num_processes: int = Non
     """
     # If num_processes is not specified, use the number of available CPUs
     if num_processes is None:
-        num_processes = cpu_count() - 1 # Pool will default to the number of available CPUs (minus 1)
+        # Ensure at least one process is used
+        num_processes = max(cpu_count() - 1, 1)
     
     # Create a pool of worker processes
     with Pool(processes=num_processes) as pool:

--- a/multiprocessing_functions/parallel_progress_bar.py
+++ b/multiprocessing_functions/parallel_progress_bar.py
@@ -18,8 +18,9 @@ def parallel_progress_bar(func: Callable[[T], R], data: list[T], num_processes: 
     data : List[T]
         The list of data items to process.
     num_processes : int, optional
-        The number of processes to use for parallel execution. If None, it defaults 
-        to the number of available CPUs (by default None).
+        The number of processes to use for parallel execution. If ``None``,
+        it defaults to the number of available CPUs minus one with a minimum
+        of one process.
 
     Returns
     -------
@@ -34,7 +35,8 @@ def parallel_progress_bar(func: Callable[[T], R], data: list[T], num_processes: 
     [1, 4, 9, 16, 25]
     """
     if num_processes is None:
-        num_processes = cpu_count() - 1 # Pool will default to the number of available CPUs (minus 1)
+        # Ensure at least one process is used
+        num_processes = max(cpu_count() - 1, 1)
 
     # Create a pool of worker processes
     with Pool(processes=num_processes) as pool:

--- a/pytest/unit/multiprocessing_functions/test_parallel_map.py
+++ b/pytest/unit/multiprocessing_functions/test_parallel_map.py
@@ -1,0 +1,11 @@
+import multiprocessing_functions.parallel_map as pm
+
+
+def double(x: int) -> int:
+    return x * 2
+
+
+def test_parallel_map_cpu_count_minimum(monkeypatch) -> None:
+    monkeypatch.setattr(pm, "cpu_count", lambda: 1)
+    assert pm.parallel_map(double, [1, 2, 3]) == [2, 4, 6]
+

--- a/pytest/unit/multiprocessing_functions/test_parallel_progress_bar.py
+++ b/pytest/unit/multiprocessing_functions/test_parallel_progress_bar.py
@@ -1,0 +1,11 @@
+import multiprocessing_functions.parallel_progress_bar as ppb
+
+
+def incr(x: int) -> int:
+    return x + 1
+
+
+def test_parallel_progress_bar_cpu_count_minimum(monkeypatch) -> None:
+    monkeypatch.setattr(ppb, "cpu_count", lambda: 1)
+    assert ppb.parallel_progress_bar(incr, [1, 2, 3]) == [2, 3, 4]
+


### PR DESCRIPTION
## Summary
- ensure a single worker is used if cpu count is one in `parallel_map` and `parallel_progress_bar`
- clarify docstrings about the default worker count
- add regression tests for both functions

## Testing
- `pytest pytest/unit/multiprocessing_functions -q`

------
https://chatgpt.com/codex/tasks/task_e_6872cd4f13d0832585eca714a45b87ae