### PR TITLE
Fix validate_args tests

### DIFF
--- a/pytest/unit/decorators/test_validate_args.py
+++ b/pytest/unit/decorators/test_validate_args.py
@@ -30,7 +30,7 @@ def test_validate_args_failure():
     """
     Test case 2: Function raises ValueError with invalid arguments
     """
-    with pytest.raises(ValueError, match="Function arguments did not pass validation."):
+    with pytest.raises(ValueError, match="Function sample_function arguments did not pass validation."):
         sample_function(-1, 2)
 
 def test_validate_args_with_logger(caplog):


### PR DESCRIPTION
## Summary
- align error message expectation in `test_validate_args_failure`

## Testing
- `pytest pytest/unit/decorators/test_validate_args.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6872cd51015883259654d776028d572b