### PR TITLE
Add multiprocessing unit tests

### DIFF
--- a/pytest/unit/multiprocessing_functions/test_parallel_accumulate.py
+++ b/pytest/unit/multiprocessing_functions/test_parallel_accumulate.py
@@ -1,0 +1,29 @@
+import pytest
+from multiprocessing_functions.parallel_accumulate import parallel_accumulate
+
+def add(a: int, b: int) -> int:
+    return a + b
+
+
+def test_parallel_accumulate_basic() -> None:
+    """Test parallel_accumulate with a simple addition function."""
+    # Test case 1: Basic accumulate
+    data: list[int] = [1, 2, 3, 4]
+    result: list[int] = parallel_accumulate(add, data)
+    assert result == [1, 3, 6, 10]
+
+
+def test_parallel_accumulate_chunk_size() -> None:
+    """Test parallel_accumulate with a custom chunk size."""
+    # Test case 2: Custom chunk size
+    data: list[int] = [1, 2, 3, 4]
+    result: list[int] = parallel_accumulate(add, data, chunk_size=2)
+    assert result == [1, 3, 6, 10]
+
+
+def test_parallel_accumulate_empty() -> None:
+    """Test parallel_accumulate with an empty list."""
+    # Test case 3: Empty list
+    data: list[int] = []
+    result: list[int] = parallel_accumulate(add, data)
+    assert result == []

--- a/pytest/unit/multiprocessing_functions/test_parallel_apply_with_args.py
+++ b/pytest/unit/multiprocessing_functions/test_parallel_apply_with_args.py
@@ -1,0 +1,21 @@
+import pytest
+from multiprocessing_functions.parallel_apply_with_args import parallel_apply_with_args
+
+def add_offset(x: int, offset: int) -> int:
+    return x + offset
+
+
+def test_parallel_apply_with_args_basic() -> None:
+    """Test parallel_apply_with_args with an additional argument."""
+    # Test case 1: Basic usage with offset
+    data: list[int] = [1, 2, 3]
+    result: list[int] = parallel_apply_with_args(add_offset, data, args=(10,), num_processes=2)
+    assert result == [11, 12, 13]
+
+
+def test_parallel_apply_with_args_empty_data() -> None:
+    """Test parallel_apply_with_args with an empty list."""
+    # Test case 2: Empty data list
+    data: list[int] = []
+    result: list[int] = parallel_apply_with_args(add_offset, data, args=(5,))
+    assert result == []

--- a/pytest/unit/multiprocessing_functions/test_parallel_broadcast.py
+++ b/pytest/unit/multiprocessing_functions/test_parallel_broadcast.py
@@ -1,0 +1,32 @@
+import pytest
+from multiprocessing_functions.parallel_broadcast import parallel_broadcast
+
+def multiply_shared(x: int, shared: int) -> int:
+    return x * shared
+
+def add_shared(x: int, shared: int) -> int:
+    return x + shared
+
+
+def test_parallel_broadcast_basic() -> None:
+    """Test parallel_broadcast with shared multiplication."""
+    # Test case 1: Basic broadcast
+    data: list[int] = [1, 2, 3]
+    result: list[int] = parallel_broadcast(multiply_shared, 2, data)
+    assert result == [2, 4, 6]
+
+
+def test_parallel_broadcast_custom_processes() -> None:
+    """Test parallel_broadcast with a custom process count."""
+    # Test case 2: Custom num_processes
+    data: list[int] = [1, 2, 3]
+    result: list[int] = parallel_broadcast(add_shared, 5, data, num_processes=2)
+    assert result == [6, 7, 8]
+
+
+def test_parallel_broadcast_empty_data() -> None:
+    """Test parallel_broadcast with an empty list."""
+    # Test case 3: Empty data list
+    data: list[int] = []
+    result: list[int] = parallel_broadcast(multiply_shared, 2, data)
+    assert result == []

--- a/pytest/unit/multiprocessing_functions/test_parallel_dynamic_distribute.py
+++ b/pytest/unit/multiprocessing_functions/test_parallel_dynamic_distribute.py
@@ -1,0 +1,21 @@
+import pytest
+from multiprocessing_functions.parallel_dynamic_distribute import parallel_dynamic_distribute
+
+def square(x: int) -> int:
+    return x * x
+
+
+def test_parallel_dynamic_distribute_basic() -> None:
+    """Test dynamic distribution with a square function."""
+    # Test case 1: Basic dynamic distribute
+    data: list[int] = [1, 2, 3, 4]
+    result: list[int] = parallel_dynamic_distribute(square, data, chunk_size=2)
+    assert result == [1, 4, 9, 16]
+
+
+def test_parallel_dynamic_distribute_empty() -> None:
+    """Test dynamic distribution with an empty list."""
+    # Test case 2: Empty list
+    data: list[int] = []
+    result: list[int] = parallel_dynamic_distribute(square, data)
+    assert result == []

--- a/pytest/unit/multiprocessing_functions/test_parallel_filter.py
+++ b/pytest/unit/multiprocessing_functions/test_parallel_filter.py
@@ -1,0 +1,32 @@
+import pytest
+from multiprocessing_functions.parallel_filter import parallel_filter
+
+def is_even(x: int) -> bool:
+    return x % 2 == 0
+
+def greater_than_two(x: int) -> bool:
+    return x > 2
+
+
+def test_parallel_filter_basic() -> None:
+    """Test parallel_filter to keep even numbers."""
+    # Test case 1: Filter even numbers
+    data: list[int] = [1, 2, 3, 4, 5, 6]
+    result: list[int] = parallel_filter(is_even, data)
+    assert result == [2, 4, 6]
+
+
+def test_parallel_filter_custom_processes() -> None:
+    """Test parallel_filter with custom num_processes."""
+    # Test case 2: Custom num_processes
+    data: list[int] = [1, 2, 3, 4]
+    result: list[int] = parallel_filter(greater_than_two, data, num_processes=2)
+    assert result == [3, 4]
+
+
+def test_parallel_filter_empty() -> None:
+    """Test parallel_filter with an empty list."""
+    # Test case 3: Empty list
+    data: list[int] = []
+    result: list[int] = parallel_filter(is_even, data)
+    assert result == []

--- a/pytest/unit/multiprocessing_functions/test_parallel_gather_errors.py
+++ b/pytest/unit/multiprocessing_functions/test_parallel_gather_errors.py
@@ -1,0 +1,28 @@
+import pytest
+from multiprocessing_functions.parallel_gather_errors import parallel_gather_errors
+
+def risky(x: int) -> int:
+    if x == 2:
+        raise ValueError("bad")
+    return x * x
+
+def inc(x: int) -> int:
+    return x + 1
+
+
+def test_parallel_gather_errors_with_exception() -> None:
+    """Test gathering errors when some inputs raise exceptions."""
+    # Test case 1: Function raises error for certain values
+    data: list[int] = [1, 2, 3]
+    results, errors = parallel_gather_errors(risky, data)
+    assert results == [1, 9]
+    assert len(errors) == 1 and isinstance(errors[0], ValueError)
+
+
+def test_parallel_gather_errors_no_error() -> None:
+    """Test when function does not raise any exceptions."""
+    # Test case 2: No errors
+    data: list[int] = [1, 2, 3]
+    results, errors = parallel_gather_errors(inc, data)
+    assert results == [2, 3, 4]
+    assert errors == []

--- a/pytest/unit/multiprocessing_functions/test_parallel_map.py
+++ b/pytest/unit/multiprocessing_functions/test_parallel_map.py
@@ -1,0 +1,31 @@
+import pytest
+from multiprocessing_functions.parallel_map import parallel_map
+
+def square(x: int) -> int:
+    return x * x
+
+def add_one(x: int) -> int:
+    return x + 1
+
+def test_parallel_map_basic() -> None:
+    """Test the parallel_map function with a simple square function."""
+    # Test case 1: Basic square mapping
+    data: list[int] = [1, 2, 3, 4]
+    result: list[int] = parallel_map(square, data)
+    assert result == [1, 4, 9, 16]
+
+
+def test_parallel_map_custom_processes() -> None:
+    """Test the parallel_map function with a specific number of processes."""
+    # Test case 2: Custom num_processes
+    data: list[int] = [1, 2, 3, 4]
+    result: list[int] = parallel_map(add_one, data, num_processes=2)
+    assert result == [2, 3, 4, 5]
+
+
+def test_parallel_map_empty_list() -> None:
+    """Test the parallel_map function with an empty list."""
+    # Test case 3: Empty list
+    data: list[int] = []
+    result: list[int] = parallel_map(square, data)
+    assert result == []

--- a/pytest/unit/multiprocessing_functions/test_parallel_pipeline.py
+++ b/pytest/unit/multiprocessing_functions/test_parallel_pipeline.py
@@ -1,0 +1,29 @@
+import pytest
+from multiprocessing_functions.parallel_pipeline import parallel_pipeline
+
+def square(x: int) -> int:
+    return x * x
+
+def add_one(x: int) -> int:
+    return x + 1
+
+def double(x: int) -> int:
+    return x * 2
+
+
+def test_parallel_pipeline_basic() -> None:
+    """Test pipeline of squaring then adding one."""
+    # Test case 1: Basic pipeline
+    funcs = [square, add_one]
+    data: list[int] = [1, 2, 3]
+    result: list[int] = parallel_pipeline(funcs, data)
+    assert result == [2, 5, 10]
+
+
+def test_parallel_pipeline_empty() -> None:
+    """Test pipeline with empty data list."""
+    # Test case 2: Empty data list
+    funcs = [double]
+    data: list[int] = []
+    result: list[int] = parallel_pipeline(funcs, data)
+    assert result == []

--- a/pytest/unit/multiprocessing_functions/test_parallel_progress_bar.py
+++ b/pytest/unit/multiprocessing_functions/test_parallel_progress_bar.py
@@ -1,0 +1,24 @@
+import pytest
+from multiprocessing_functions.parallel_progress_bar import parallel_progress_bar
+
+def square(x: int) -> int:
+    return x * x
+
+def add_one(x: int) -> int:
+    return x + 1
+
+
+def test_parallel_progress_bar_basic() -> None:
+    """Test progress bar parallel execution."""
+    # Test case 1: Basic progress bar
+    data: list[int] = [1, 2, 3]
+    result: list[int] = parallel_progress_bar(square, data)
+    assert result == [1, 4, 9]
+
+
+def test_parallel_progress_bar_custom_processes() -> None:
+    """Test progress bar with custom num_processes."""
+    # Test case 2: Custom num_processes
+    data: list[int] = [1, 2, 3]
+    result: list[int] = parallel_progress_bar(add_one, data, num_processes=2)
+    assert result == [2, 3, 4]

--- a/pytest/unit/multiprocessing_functions/test_parallel_reduce.py
+++ b/pytest/unit/multiprocessing_functions/test_parallel_reduce.py
@@ -1,0 +1,21 @@
+import pytest
+from multiprocessing_functions.parallel_reduce import parallel_reduce
+
+def add(a: int, b: int) -> int:
+    return a + b
+
+
+def test_parallel_reduce_basic() -> None:
+    """Test parallel_reduce summing numbers."""
+    # Test case 1: Basic sum reduction
+    data: list[int] = [1, 2, 3, 4]
+    result: int = parallel_reduce(add, data)
+    assert result == 10
+
+
+def test_parallel_reduce_chunk_size() -> None:
+    """Test parallel_reduce with a custom chunk size."""
+    # Test case 2: Custom chunk size
+    data: list[int] = [1, 2, 3, 4]
+    result: int = parallel_reduce(add, data, chunk_size=2)
+    assert result == 10

--- a/pytest/unit/multiprocessing_functions/test_parallel_sort.py
+++ b/pytest/unit/multiprocessing_functions/test_parallel_sort.py
@@ -1,0 +1,18 @@
+import pytest
+from multiprocessing_functions.parallel_sort import parallel_sort
+
+
+def test_parallel_sort_basic() -> None:
+    """Test parallel_sort on an unsorted list."""
+    # Test case 1: Basic sorting
+    data: list[int] = [5, 2, 3, 1, 4]
+    result: list[int] = parallel_sort(data)
+    assert result == [1, 2, 3, 4, 5]
+
+
+def test_parallel_sort_chunk_size() -> None:
+    """Test parallel_sort with a specific chunk size."""
+    # Test case 2: Custom chunk size
+    data: list[int] = [4, 3, 2, 1]
+    result: list[int] = parallel_sort(data, chunk_size=2)
+    assert result == [1, 2, 3, 4]

--- a/pytest/unit/multiprocessing_functions/test_parallel_starmap.py
+++ b/pytest/unit/multiprocessing_functions/test_parallel_starmap.py
@@ -1,0 +1,24 @@
+import pytest
+from multiprocessing_functions.parallel_starmap import parallel_starmap
+
+def multiply(a: int, b: int) -> int:
+    return a * b
+
+def add(a: int, b: int) -> int:
+    return a + b
+
+
+def test_parallel_starmap_basic() -> None:
+    """Test parallel_starmap multiplying pairs of numbers."""
+    # Test case 1: Basic starmap
+    data: list[tuple[int, int]] = [(1, 2), (3, 4), (5, 6)]
+    result: list[int] = parallel_starmap(multiply, data)
+    assert result == [2, 12, 30]
+
+
+def test_parallel_starmap_empty() -> None:
+    """Test parallel_starmap with an empty list."""
+    # Test case 2: Empty data
+    data: list[tuple[int, int]] = []
+    result: list[int] = parallel_starmap(add, data)
+    assert result == []

--- a/pytest/unit/multiprocessing_functions/test_parallel_sum.py
+++ b/pytest/unit/multiprocessing_functions/test_parallel_sum.py
@@ -1,0 +1,18 @@
+import pytest
+from multiprocessing_functions.parallel_sum import parallel_sum
+
+
+def test_parallel_sum_basic() -> None:
+    """Test summing a list of integers."""
+    # Test case 1: Basic sum
+    data: list[int] = [1, 2, 3, 4]
+    result: int = parallel_sum(data)
+    assert result == 10
+
+
+def test_parallel_sum_chunk_size() -> None:
+    """Test parallel_sum with a specific chunk size."""
+    # Test case 2: Custom chunk size
+    data: list[int] = [1, 2, 3, 4]
+    result: int = parallel_sum(data, chunk_size=2)
+    assert result == 10

--- a/pytest/unit/multiprocessing_functions/test_parallel_unique.py
+++ b/pytest/unit/multiprocessing_functions/test_parallel_unique.py
@@ -1,0 +1,18 @@
+import pytest
+from multiprocessing_functions.parallel_unique import parallel_unique
+
+
+def test_parallel_unique_basic() -> None:
+    """Test extracting unique elements from a list."""
+    # Test case 1: Basic unique
+    data: list[int] = [1, 2, 2, 3, 3, 4]
+    result: list[int] = parallel_unique(data)
+    assert sorted(result) == [1, 2, 3, 4]
+
+
+def test_parallel_unique_chunk_size() -> None:
+    """Test parallel_unique with a custom chunk size."""
+    # Test case 2: Custom chunk size
+    data: list[int] = [1, 1, 2, 2, 3]
+    result: list[int] = parallel_unique(data, chunk_size=2)
+    assert sorted(result) == [1, 2, 3]


### PR DESCRIPTION
## Summary
- add tests for multiprocessing utilities: map, reduce, accumulate, broadcast, dynamic distribute, filter, gather errors, pipeline, progress bar, sum, sort, starmap, unique, apply with args

## Testing
- `pytest pytest/unit/multiprocessing_functions/test_parallel_map.py::test_parallel_map_basic -q`
- `pytest -q` *(fails: AttributeError: Can't pickle local object 'parallel_accumulate.<locals>.partial_accumulate')*

------
https://chatgpt.com/codex/tasks/task_e_68737af9254c8325aa6dc0c513b1847d