### PR TITLE
Update async function type hints

### DIFF
--- a/asyncio_functions/async_map.py
+++ b/asyncio_functions/async_map.py
@@ -1,17 +1,17 @@
 import asyncio
-from typing import TypeVar
+from typing import TypeVar, Awaitable
 from collections.abc import Callable
 
 T = TypeVar('T')
 R = TypeVar('R')
 
-async def async_map(func: Callable[[T], R], items: list[T]) -> list[R]:
+async def async_map(func: Callable[[T], Awaitable[R]], items: list[T]) -> list[R]:
     """
     Apply an asynchronous function to a list of items concurrently.
 
     Parameters
     ----------
-    func : Callable[[T], R]
+    func : Callable[[T], Awaitable[R]]
         The asynchronous function to apply to each item.
     items : List[T]
         The list of items to process.

--- a/asyncio_functions/async_retry_with_backoff.py
+++ b/asyncio_functions/async_retry_with_backoff.py
@@ -1,17 +1,22 @@
 import asyncio
-from typing import TypeVar
+from typing import TypeVar, Awaitable
 from collections.abc import Callable
 
 # Define a type variable T to represent the return type of the function
 T = TypeVar('T')
 
-async def async_retry_with_backoff(func: Callable[[], T], retries: int, initial_delay: float, backoff_factor: float) -> T:
+async def async_retry_with_backoff(
+    func: Callable[..., Awaitable[T]],
+    retries: int,
+    initial_delay: float,
+    backoff_factor: float,
+) -> T:
     """
     Retry an asynchronous function on failure, using exponential backoff.
 
     Parameters
     ----------
-    func : Callable[[], T]
+    func : Callable[..., Awaitable[T]]
         The asynchronous function to retry.
     retries : int
         The maximum number of retry attempts.

--- a/asyncio_functions/async_stream_processor.py
+++ b/asyncio_functions/async_stream_processor.py
@@ -1,8 +1,12 @@
 from collections.abc import Callable
 from collections.abc import AsyncIterator
+from typing import Awaitable
 
 # Define an asynchronous function to process a stream of data
-async def async_stream_processor(stream: AsyncIterator[str], process: Callable[[str], None]) -> None:
+async def async_stream_processor(
+    stream: AsyncIterator[str],
+    process: Callable[[str], Awaitable[None]],
+) -> None:
     """
     Process a stream of data asynchronously.
 
@@ -10,8 +14,8 @@ async def async_stream_processor(stream: AsyncIterator[str], process: Callable[[
     ----------
     stream : AsyncIterator[str]
         An asynchronous iterator representing the data stream.
-    process : Callable[[str], None]
-        A function to process each item from the stream.
+    process : Callable[[str], Awaitable[None]]
+        An asynchronous function to process each item from the stream.
 
     Returns
     -------

--- a/asyncio_functions/async_timeout.py
+++ b/asyncio_functions/async_timeout.py
@@ -1,17 +1,17 @@
-from typing import TypeVar
+from typing import TypeVar, Awaitable
 from collections.abc import Callable
 import asyncio
 
 # Define a type variable T to represent the return type of the function
 T = TypeVar('T')
 
-async def async_timeout(func: Callable[[], T], timeout: float) -> T:
+async def async_timeout(func: Callable[..., Awaitable[T]], timeout: float) -> T:
     """
     Add a timeout to an asynchronous function.
 
     Parameters
     ----------
-    func : Callable[[], T]
+    func : Callable[..., Awaitable[T]]
         The asynchronous function to run.
     timeout : float
         The time in seconds after which to timeout the function.

--- a/asyncio_functions/retry_async.py
+++ b/asyncio_functions/retry_async.py
@@ -1,17 +1,21 @@
-from typing import TypeVar
+from typing import TypeVar, Awaitable
 from collections.abc import Callable
 import asyncio
 
 # Define a type variable for the return type of the function
 T = TypeVar('T')
 
-async def retry_async(func: Callable[[], T], retries: int, delay: float) -> T:
+async def retry_async(
+    func: Callable[..., Awaitable[T]],
+    retries: int,
+    delay: float,
+) -> T:
     """
     Retry an asynchronous function a specified number of times if it fails.
 
     Parameters
     ----------
-    func : Callable[[], T]
+    func : Callable[..., Awaitable[T]]
         The asynchronous function to retry.
     retries : int
         The maximum number of retry attempts.

--- a/asyncio_functions/run_in_parallel.py
+++ b/asyncio_functions/run_in_parallel.py
@@ -1,16 +1,16 @@
-from typing import TypeVar
+from typing import TypeVar, Awaitable
 from collections.abc import Callable
 import asyncio
 
 T = TypeVar('T')
 
-async def run_in_parallel(tasks: list[Callable[[], T]]) -> list[T]:
+async def run_in_parallel(tasks: list[Callable[..., Awaitable[T]]]) -> list[T]:
     """
     Run multiple asynchronous functions in parallel.
 
     Parameters
     ----------
-    tasks : List[Callable[[], T]]
+    tasks : list[Callable[..., Awaitable[T]]]
         A list of asynchronous functions to execute.
 
     Returns


### PR DESCRIPTION
## Summary
- use `Callable[..., Awaitable]` style hints in asyncio utilities
- document updated signatures

## Testing
- `flake8`
- `mypy --explicit-package-bases asyncio_functions/async_timeout.py asyncio_functions/async_map.py asyncio_functions/async_retry_with_backoff.py asyncio_functions/retry_async.py asyncio_functions/run_in_parallel.py asyncio_functions/async_stream_processor.py`
- `pytest -q` *(fails: 30 failed, 841 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6877f63baae88325a6354def8154be2a