### PR TITLE
Add explicit typing to async connection pool methods

### DIFF
--- a/asyncio_functions/async_connection_pool.py
+++ b/asyncio_functions/async_connection_pool.py
@@ -30,7 +30,7 @@ class AsyncConnectionPool:
         self.max_connections = max_connections
         self._pool: asyncio.Queue[Any] = asyncio.Queue(max_connections)
 
-    async def acquire(self):
+    async def acquire(self) -> Any:
         """
         Acquire a connection from the pool.
 
@@ -43,7 +43,7 @@ class AsyncConnectionPool:
         conn = await self._pool.get()
         return conn
 
-    async def release(self, conn):
+    async def release(self, conn: Any) -> None:
         """
         Release a connection back to the pool.
 
@@ -55,7 +55,7 @@ class AsyncConnectionPool:
         # Put the connection back into the pool
         await self._pool.put(conn)
 
-    async def add_connection(self, conn):
+    async def add_connection(self, conn: Any) -> None:
         """
         Add a new connection to the pool.
 


### PR DESCRIPTION
## Summary
- add return type hints for `acquire`, `release`, and `add_connection`
- annotate connection parameters with `Any`
- keep generic typing for `use_connection`

## Testing
- `pytest -q` *(fails: 30 failed, 841 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6877f6457fb08325b40791f83c00dbd3