### PR TITLE
Fix None comparisons

### DIFF
--- a/multiprocessing_functions/parallel_sort.py
+++ b/multiprocessing_functions/parallel_sort.py
@@ -41,7 +41,7 @@ def parallel_sort(data: list[int], num_processes: int = None, chunk_size: int = 
         result.extend(right[j:])
         return result
 
-    if num_processes == None:
+    if num_processes is None:
         num_processes = cpu_count() - 1 # Pool will default to the number of available CPUs (minus 1)
 
     # Create a pool of worker processes

--- a/multiprocessing_functions/parallel_sum.py
+++ b/multiprocessing_functions/parallel_sum.py
@@ -24,7 +24,7 @@ def parallel_sum(data: list[int], num_processes: int = None, chunk_size: int = 1
     >>> parallel_sum([1, 2, 3, 4, 5])
     15
     """
-    if num_processes == None:
+    if num_processes is None:
         num_processes = cpu_count() - 1 # Pool will default to the number of available CPUs (minus 1)
     
     # Create a pool of worker processes

--- a/print_functions/print_message.py
+++ b/print_functions/print_message.py
@@ -42,7 +42,7 @@ def print_message(message: str, message_type: str = "info", end: str = '\n', flu
         formatted_message = f"[ERROR] {current_time} - {message}"
     elif message_type == "debug":
         formatted_message = f"[DEBUG] {current_time} - {message}"
-    elif message_type == None:
+    elif message_type is None:
         formatted_message = f"{message}"
     else:
         formatted_message = f"{current_time} - {message}"


### PR DESCRIPTION
## Summary
- use `is None` comparisons in print_message, parallel_sort and parallel_sum

## Testing
- `pytest pytest/unit/multiprocessing_functions/test_parallel_sum.py pytest/unit/multiprocessing_functions/test_parallel_sort.py -q` *(fails: Can't pickle local object `parallel_sort.<locals>.merge`)*

------
https://chatgpt.com/codex/tasks/task_e_687a23b3ac7c8325adc98fe33721f652