### PR TITLE
Fix whitespace in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,10 +8,10 @@ packaging==24.2
 pluggy==1.5.0
 pytest==8.4.1
 python-snappy==0.7.3
-tomli==2.1.0 
+tomli==2.1.0
 zstandard==0.23.0
 psutil==6.1.1
 pytest-asyncio==1.0.0
-tqdm==4.67.1 
+tqdm==4.67.1
 pylint==3.2.2
 mypy==1.16.1


### PR DESCRIPTION
## Summary
- remove trailing spaces from `requirements.txt`
- ensure newline at end of file

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q` *(fails: 30 failed, 843 passed)*

------
https://chatgpt.com/codex/tasks/task_e_687a23b836a88325a491e7c69c04be30