### PR TITLE
Preserve original exception in log_function_calls

### DIFF
--- a/decorators/log_function_calls.py
+++ b/decorators/log_function_calls.py
@@ -55,7 +55,7 @@ def log_function_calls(logger: logging.Logger) -> Callable[[Callable[..., Any]],
                 return result
             except Exception as e:
                 logger.error(f"Exception in {func.__name__}: {e}", exc_info=True)
-                raise Exception(f"Exception in {func.__name__}:") from e
+                raise
 
         return wrapper
     

--- a/pytest/unit/decorators/test_log_function_calls.py
+++ b/pytest/unit/decorators/test_log_function_calls.py
@@ -95,7 +95,7 @@ def test_log_function_calls_function_raises_error(caplog: pytest.LogCaptureFixtu
     Test case 6: Log function calls when the wrapped function raises an error
     """
     with caplog.at_level(logging.INFO):
-        with pytest.raises(Exception, match="Exception in sample_function_raises_error:"):
+        with pytest.raises(ValueError, match="An error occurred"):
             sample_function_raises_error(1, "test")
     assert "Calling sample_function_raises_error with args: (1, 'test') and kwargs: {}" in caplog.text
     assert "Exception in sample_function_raises_error:" in caplog.text


### PR DESCRIPTION
## Summary
- return the original exception in `log_function_calls`
- update unit test expectations for new behavior

## Testing
- `pytest pytest/unit/decorators/test_log_function_calls.py::test_log_function_calls_function_raises_error -q`


------
https://chatgpt.com/codex/tasks/task_e_687f4e606ed883259405661611f0a8e0