### PR TITLE
Improve Queue/Deque performance using deque

### DIFF
--- a/data_types/Deque.py
+++ b/data_types/Deque.py
@@ -1,16 +1,18 @@
 from typing import TypeVar, Generic
+from collections import deque
 
 # Define a generic type variable
 T = TypeVar('T')
 
 class Deque(Generic[T]):
     """
-    A Deque (Double-Ended Queue) data structure.
+    A Deque (Double-Ended Queue) data structure implemented using
+    :class:`collections.deque`. All operations run in constant time.
 
     Attributes
     ----------
-    items : List[T]
-        The list to store deque elements.
+    items : deque[T]
+        The deque storing elements.
 
     Methods
     -------
@@ -32,7 +34,7 @@ class Deque(Generic[T]):
         """
         Initializes an empty deque.
         """
-        self.items: list[T] = []
+        self.items: deque[T] = deque()
 
     def add_front(self, item: T) -> None:
         """
@@ -43,7 +45,7 @@ class Deque(Generic[T]):
         item : T
             The element to add to the deque.
         """
-        self.items.insert(0, item)
+        self.items.appendleft(item)
 
     def add_rear(self, item: T) -> None:
         """
@@ -72,7 +74,7 @@ class Deque(Generic[T]):
         """
         if self.is_empty():
             raise IndexError("Remove from an empty deque")
-        return self.items.pop(0)
+        return self.items.popleft()
 
     def remove_rear(self) -> T:
         """

--- a/data_types/Queue.py
+++ b/data_types/Queue.py
@@ -1,16 +1,19 @@
 from typing import TypeVar, Generic
+from collections import deque
 
 # Define a generic type variable
 T = TypeVar('T')
 
 class Queue(Generic[T]):
     """
-    A Queue data structure.
+    A Queue data structure built on :class:`collections.deque`.
+    All queue operations run in constant time.
 
     Attributes
     ----------
-    items : List[T]
-        The list to store queue elements.
+    items : deque[T]
+        A deque to store queue elements. Operations from the front or
+        back run in constant time.
 
     Methods
     -------
@@ -28,7 +31,7 @@ class Queue(Generic[T]):
         """
         Initializes an empty queue.
         """
-        self.items: list[T] = []
+        self.items: deque[T] = deque()
 
     def enqueue(self, item: T) -> None:
         """
@@ -57,7 +60,7 @@ class Queue(Generic[T]):
         """
         if self.is_empty():
             raise IndexError("Dequeue from an empty queue")
-        return self.items.pop(0)
+        return self.items.popleft()
 
     def is_empty(self) -> bool:
         """

--- a/pytest/unit/data_types/test_Deque.py
+++ b/pytest/unit/data_types/test_Deque.py
@@ -9,7 +9,7 @@ def test_add_front() -> None:
     deque = Deque[int]()
     deque.add_front(10)
     deque.add_front(20)
-    assert deque.items == [20, 10]  # The most recent element should be at the front
+    assert list(deque.items) == [20, 10]  # The most recent element should be at the front
 
 def test_add_rear() -> None:
     """
@@ -19,7 +19,7 @@ def test_add_rear() -> None:
     deque = Deque[int]()
     deque.add_rear(10)
     deque.add_rear(20)
-    assert deque.items == [10, 20]  # The most recent element should be at the rear
+    assert list(deque.items) == [10, 20]  # The most recent element should be at the rear
 
 def test_remove_front() -> None:
     """
@@ -30,7 +30,7 @@ def test_remove_front() -> None:
     deque.add_front(10)
     deque.add_front(20)
     assert deque.remove_front() == 20  # The front element should be removed
-    assert deque.items == [10]
+    assert list(deque.items) == [10]
 
 def test_remove_rear() -> None:
     """
@@ -41,7 +41,7 @@ def test_remove_rear() -> None:
     deque.add_rear(10)
     deque.add_rear(20)
     assert deque.remove_rear() == 20  # The rear element should be removed
-    assert deque.items == [10]
+    assert list(deque.items) == [10]
 
 def test_is_empty_on_empty_deque() -> None:
     """
@@ -106,10 +106,10 @@ def test_mixed_operations() -> None:
     deque.add_rear(20)
     deque.add_front(5)
     deque.add_rear(25)
-    assert deque.items == [5, 10, 20, 25]
+    assert list(deque.items) == [5, 10, 20, 25]
     assert deque.remove_front() == 5
     assert deque.remove_rear() == 25
-    assert deque.items == [10, 20]
+    assert list(deque.items) == [10, 20]
     assert deque.size() == 2
     assert deque.is_empty() is False
 


### PR DESCRIPTION
## Summary
- switch Queue and Deque to use `collections.deque`
- update operations to use `popleft`/`appendleft`
- adjust unit tests for new `deque` internals

## Testing
- `pytest -q` *(fails: 30 failed, 843 passed)*

------
https://chatgpt.com/codex/tasks/task_e_687fc2da6ff8832589a5bae88d12aeea