### PR TITLE
Fix async_handle_error behavior

### DIFF
--- a/pytest/unit/decorators/test_async_handle_error.py
+++ b/pytest/unit/decorators/test_async_handle_error.py
@@ -102,8 +102,7 @@ async def test_async_function_exception():
     """
     # Test case 7: Asynchronous function that raises an ValueError
     with pytest.raises(ValueError, match="Test exception"):
-        result = await sample_function_exception(1, 2)
-    assert result is None
+        await sample_function_exception(1, 2)
 
 
 def test_non_async_function_with_logger(caplog):


### PR DESCRIPTION
## Summary
- ensure `async_handle_error` re-raises when no logger is provided
- update docstrings
- adjust unit test to expect raised exception

## Testing
- `pytest -q pytest/unit/decorators/test_async_handle_error.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688136cf857c8325bdff9acc93d81aa2