### PR TITLE
Improve logger utility clarity

### DIFF
--- a/logger_functions/logger.py
+++ b/logger_functions/logger.py
@@ -1,3 +1,5 @@
+"""Utilities for creating module-specific loggers and validating logger instances."""
+
 import logging
 from logging import Logger, NullHandler
 
@@ -9,7 +11,12 @@ def get_logger(name: str = __name__) -> Logger:
     return logger
 
 
-def validate_logger(logger: Logger | None, *, allow_none: bool = True, message: str | None = None) -> None:
+def validate_logger(
+    logger: Logger | None,
+    *,
+    allow_none: bool = True,
+    message: str | None = None,
+) -> None:
     """Validate that ``logger`` is a ``logging.Logger`` or ``None``.
 
     Parameters
@@ -33,4 +40,4 @@ def validate_logger(logger: Logger | None, *, allow_none: bool = True, message: 
         raise TypeError(message)
 
 
-logger = get_logger(__name__)
+module_logger = get_logger(__name__)


### PR DESCRIPTION
## Summary
- document `logger_functions.logger` module
- split long signature in `validate_logger`
- rename module-level logger to `module_logger`

## Testing
- `pytest -q` *(fails: 28 failed, 845 passed)*

------
https://chatgpt.com/codex/tasks/task_e_688146c554bc8325a4c1b6c04d897066