### PR TITLE
Move test deps to optional extras

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ pip install -r requirements.txt
 
 # install additional packages for development and testing
 pip install -r requirements_dev.txt
+# alternatively install the optional "dev" extras defined in `pyproject.toml`
+pip install -e .[dev]
 ```
 `tqdm` is used for progress bars and is installed with the runtime requirements file.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,21 +6,25 @@ build-backend = "setuptools.build_meta"
 name = "python-utils"
 version = "0.1.0"
 dependencies = [
+    "cramjam==2.10.0",
+    "python-snappy==0.7.3",
+    "zstandard==0.23.0",
+    "psutil==7.0.0",
+    "tqdm==4.67.1",
+]
+
+[project.optional-dependencies]
+dev = [
     "allure-pytest==2.14.3",
     "allure-python-commons==2.14.3",
     "attrs==25.3.0",
-    "cramjam==2.10.0",
     "exceptiongroup==1.3.0",
     "iniconfig==2.1.0",
     "packaging==25.0",
     "pluggy==1.6.0",
     "pytest==8.4.1",
-    "python-snappy==0.7.3",
-    "tomli==2.2.1",
-    "zstandard==0.23.0",
-    "psutil==7.0.0",
     "pytest-asyncio==1.1.0",
-    "tqdm==4.67.1",
+    "tomli==2.2.1",
     "pylint==3.3.7",
     "mypy==1.17.0",
 ]


### PR DESCRIPTION
## Summary
- strip dev dependencies from `project.dependencies`
- define `[project.optional-dependencies.dev]`
- mention optional extras in README

## Testing
- `pip install -r requirements_dev.txt`
- `pytest -q` *(fails: 39 failed, 1428 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6886141f3ac483259288a00fc6a3cc68