### PR TITLE
Fix verify_password custom checks default

### DIFF
--- a/pytest/unit/strings_utility/test_verify_password.py
+++ b/pytest/unit/strings_utility/test_verify_password.py
@@ -87,3 +87,20 @@ def test_verify_password_invalid_type() -> None:
     # Test case 10: Invalid type
     with pytest.raises(TypeError):
         verify_password(12345)
+
+
+def test_verify_password_no_shared_state() -> None:
+    """
+    Test that repeated calls do not share state between invocations.
+    """
+    calls: list[str] = []
+
+    def custom_check(p: str) -> bool:
+        calls.append(p)
+        return True
+
+    assert verify_password("Password123!", custom_checks=[custom_check])
+    assert calls == ["Password123!"]
+
+    assert verify_password("Password123!")
+    assert calls == ["Password123!"]

--- a/strings_utility/verify_password.py
+++ b/strings_utility/verify_password.py
@@ -1,9 +1,10 @@
 import re
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 
 
 def verify_password(
-    password: str, custom_checks: list[Callable[[str], bool]] = []
+    password: str,
+    custom_checks: Iterable[Callable[[str], bool]] | None = None,
 ) -> bool:
     """
     Verify if a password meets the following criteria:
@@ -17,8 +18,9 @@ def verify_password(
     ----------
     password : str
         The password to verify.
-    custom_checks : List[Callable[[str], bool]], optional
-        A list of custom check functions that take the password as input and return a boolean.
+    custom_checks : Iterable[Callable[[str], bool]], optional
+        An iterable of custom check functions that take the password as input and
+        return a boolean. Defaults to ``None``.
 
     Returns
     -------
@@ -28,7 +30,8 @@ def verify_password(
     Raises
     ------
     TypeError
-        If the password is not a string or if custom_checks is not a list of callables.
+        If the password is not a string or if ``custom_checks`` is not an
+        iterable of callables.
 
     Examples
     --------
@@ -48,10 +51,13 @@ def verify_password(
     """
     if not isinstance(password, str):
         raise TypeError("The password must be a string.")
-    if not isinstance(custom_checks, list) or not all(
-        callable(check) for check in custom_checks
-    ):
-        raise TypeError("custom_checks must be a list of callables.")
+
+    if custom_checks is None:
+        custom_checks = []
+    elif not isinstance(custom_checks, Iterable) or isinstance(
+        custom_checks, (str, bytes)
+    ) or not all(callable(check) for check in custom_checks):
+        raise TypeError("custom_checks must be an iterable of callables.")
 
     # Check if the password is at least 8 characters long
     if len(password) < 8:


### PR DESCRIPTION
## Summary
- avoid mutable default argument in `verify_password`
- update docstring accordingly
- test that repeated calls do not share state

## Testing
- `pytest pytest/unit/strings_utility/test_verify_password.py -q`
- `pytest -q` *(fails: 28 failed, 845 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6886141c2c9483259037cd806398214d