### PR TITLE
Fix context switch fallback in time_and_resource_function

### DIFF
--- a/decorators/time_and_resource_function.py
+++ b/decorators/time_and_resource_function.py
@@ -3,6 +3,7 @@ import psutil
 import logging
 import threading
 import gc
+from types import SimpleNamespace
 from logger_functions.logger import validate_logger
 from typing import Any
 from collections.abc import Callable
@@ -137,7 +138,7 @@ def time_and_resource_function(
                         if hasattr(process, "num_ctx_switches"):
                             context_switches = process.num_ctx_switches()
                         else:
-                            context_switches = psutil._common.pctxsw(0, 0)
+                            context_switches = SimpleNamespace(voluntary=0, involuntary=0)
 
                         # Monitor GC statistics
                         if monitor_gc:


### PR DESCRIPTION
## Summary
- avoid private psutil access when context switch data is unavailable

## Testing
- `pytest pytest/unit/decorators/test_time_and_resource_function.py -q` *(fails: Execution time not logged)*

------
https://chatgpt.com/codex/tasks/task_e_6889265441548325a9bdd1d6749b0f2b