### PR TITLE
Add aiohttp and pandas deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ pip install -r requirements_dev.txt
 # alternatively install the optional "dev" extras defined in `pyproject.toml`
 pip install -e .[dev]
 ```
-`tqdm` is used for progress bars and is installed with the runtime requirements file.
+`tqdm` is used for progress bars. The runtime requirements file also installs
+`aiohttp` for asynchronous HTTP helpers and `pandas` for the dataframe utilities.
 
 ## Running Tests
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,8 @@ dependencies = [
     "zstandard==0.23.0",
     "psutil==7.0.0",
     "tqdm==4.67.1",
+    "aiohttp==3.12.15",
+    "pandas==2.3.1",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ python-snappy==0.7.3
 zstandard==0.23.0
 psutil==7.0.0
 tqdm==4.67.1
+aiohttp==3.12.15
+pandas==2.3.1


### PR DESCRIPTION
## Summary
- add `aiohttp` and `pandas` runtime dependencies
- mention new runtime packages in README

## Testing
- `pip install -r requirements_dev.txt`
- `pytest -q` *(fails: 28 failed, 845 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6889265474448325ab5520491c59acdb