### PR TITLE
Bump cramjam to 2.11.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "python-utils"
 version = "0.1.0"
 requires-python = ">=3.10"
 dependencies = [
-    "cramjam==2.10.0",
+    "cramjam==2.11.0",
     "python-snappy==0.7.3",
     "zstandard==0.23.0",
     "psutil==7.0.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-cramjam==2.10.0
+cramjam==2.11.0
 python-snappy==0.7.3
 zstandard==0.23.0
 psutil==7.0.0


### PR DESCRIPTION
## Summary
- upgrade `cramjam` dependency to 2.11.0

## Testing
- `bash pytest.sh pytest/unit pytest_run_tests/allure-results pytest_run_tests/allure-report false` *(fails: 28 failed, 845 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68892656d0188325aa23a5f6e086aa77