### PR TITLE
Fix deprecated warning test

### DIFF
--- a/pytest/unit/decorators/test_deprecated.py
+++ b/pytest/unit/decorators/test_deprecated.py
@@ -41,7 +41,7 @@ def test_deprecated_without_logger(capsys):
         result = old_function_no_logger()
     captured = capsys.readouterr()
     assert result == "This is an old function."
-    assert "old_function_no_logger is deprecated." in record.out
+    assert "old_function_no_logger is deprecated." in str(record[0].message)
 
 
 def test_deprecated_with_args(caplog):


### PR DESCRIPTION
## Summary
- update deprecated test to check warnings correctly

## Testing
- `pytest pytest/unit/decorators/test_deprecated.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688ba65b46108325b4416f65e3cdb2d3