### PR TITLE
Refactor timeout decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ def my_function():
     ...
 ```
 
+The `timeout` decorator is also thread-based so it works on all platforms,
+including Windows. When the specified limit is reached a `TimeoutException` is
+raised while the underlying thread may still finish in the background.
+
 ## Contributing
 
 1. Fork the repository and create a new branch.


### PR DESCRIPTION
## Summary
- use `concurrent.futures` instead of `signal.SIGALRM` in `timeout` decorator
- note cross-platform support in README and docstring
- update unit tests for timeout decorator

## Testing
- `pytest -q pytest/unit/decorators/test_timeout.py`

------
https://chatgpt.com/codex/tasks/task_e_688bb34b2a708325a97d7311373ca22a