### PR TITLE
Normalize cleanup exclusions

### DIFF
--- a/file_functions/cleanup.py
+++ b/file_functions/cleanup.py
@@ -4,7 +4,8 @@ import shutil
 
 def cleanup(directory: str, exclude: list[str]) -> None:
     """
-    Clean up a directory by removing all files and subdirectories except those specified in the exclusion list.
+    Clean up a directory by removing all files and subdirectories except those
+    specified in the exclusion list.
 
     Parameters
     ----------
@@ -12,14 +13,23 @@ def cleanup(directory: str, exclude: list[str]) -> None:
         The path to the directory to clean up.
     exclude : List[str]
         A list of filenames or subdirectory names to exclude from removal.
+        Entries may be provided either as absolute paths or names relative to
+        ``directory``. Absolute paths are normalized to their base names before
+        comparison. For example, both ``"important.txt"`` and
+        ``"/tmp/project/important.txt"`` will preserve the same file when
+        ``directory`` is ``/tmp/project``.
 
     Returns
     -------
     None
     """
+    normalized_exclude = {
+        os.path.basename(os.path.normpath(path)) for path in exclude
+    }
+
     for item in os.listdir(directory):
-        item_path = os.path.join(directory, item)
-        if item_path not in exclude:
+        if item not in normalized_exclude:
+            item_path = os.path.join(directory, item)
             if os.path.isfile(item_path) or os.path.islink(item_path):
                 os.remove(item_path)
             elif os.path.isdir(item_path):

--- a/pytest/unit/file_functions/test_cleanup.py
+++ b/pytest/unit/file_functions/test_cleanup.py
@@ -1,0 +1,44 @@
+import os
+from file_functions.cleanup import cleanup
+
+
+def test_cleanup_exclude_relative_names(tmp_path) -> None:
+    """
+    Ensure cleanup keeps items specified by relative names.
+    """
+    keep_file = tmp_path / "keep.txt"
+    keep_file.write_text("data")
+    remove_file = tmp_path / "remove.txt"
+    remove_file.write_text("data")
+    keep_dir = tmp_path / "keep_dir"
+    keep_dir.mkdir()
+    remove_dir = tmp_path / "remove_dir"
+    remove_dir.mkdir()
+
+    cleanup(str(tmp_path), ["keep.txt", "keep_dir"])
+
+    assert keep_file.exists()
+    assert keep_dir.exists()
+    assert not remove_file.exists()
+    assert not remove_dir.exists()
+
+
+def test_cleanup_exclude_absolute_paths(tmp_path) -> None:
+    """
+    Ensure cleanup keeps items specified by absolute paths.
+    """
+    keep_file = tmp_path / "keep.txt"
+    keep_file.write_text("data")
+    remove_file = tmp_path / "remove.txt"
+    remove_file.write_text("data")
+    keep_dir = tmp_path / "keep_dir"
+    keep_dir.mkdir()
+    remove_dir = tmp_path / "remove_dir"
+    remove_dir.mkdir()
+
+    cleanup(str(tmp_path), [str(keep_file), str(keep_dir)])
+
+    assert keep_file.exists()
+    assert keep_dir.exists()
+    assert not remove_file.exists()
+    assert not remove_dir.exists()


### PR DESCRIPTION
## Summary
- allow `cleanup` to accept exclusions by name or absolute path
- document exclusion behavior for absolute vs relative paths
- test cleanup handling of relative and absolute exclusions

## Testing
- `pytest -q`
- `pytest pytest/unit/file_functions/test_cleanup.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68938e082d708325ab3bbdc1100bb7b3