### PR TITLE
Ensure divide_list_into_n_chunks returns n sublists

### DIFF
--- a/iterable_functions/divide_list_into_n_chunks.py
+++ b/iterable_functions/divide_list_into_n_chunks.py
@@ -15,7 +15,9 @@ def divide_list_into_n_chunks(list_to_divide: list[Any], n: int) -> list[list[An
     Returns
     -------
     list
-        A list of sublists created by dividing the input list.
+        A list of ``n`` sublists created by dividing the input list. Some
+        sublists may be empty when ``n`` is greater than the length of the
+        input list.
 
     Raises
     ------
@@ -23,6 +25,13 @@ def divide_list_into_n_chunks(list_to_divide: list[Any], n: int) -> list[list[An
         If list_to_divide is not a list or n is not an integer.
     ValueError
         If n is less than or equal to 0.
+
+    Examples
+    --------
+    >>> divide_list_into_n_chunks([1, 2, 3, 4, 5], 2)
+    [[1, 2, 3], [4, 5]]
+    >>> divide_list_into_n_chunks([1, 2], 5)
+    [[1], [2], [], [], []]
     """
     if not isinstance(list_to_divide, list):
         raise TypeError("list_to_divide must be a list")
@@ -42,6 +51,6 @@ def divide_list_into_n_chunks(list_to_divide: list[Any], n: int) -> list[list[An
         sublists.append(list_to_divide[start_idx:end_idx])
         start_idx = end_idx
 
-    return [sublist for sublist in sublists if sublist]
+    return sublists
 
 __all__ = ['divide_list_into_n_chunks']

--- a/pytest/unit/iterable_functions/test_divide_list_into_n_chunks.py
+++ b/pytest/unit/iterable_functions/test_divide_list_into_n_chunks.py
@@ -31,7 +31,7 @@ def test_divide_list_into_n_chunks_more_chunks_than_elements() -> None:
     # Test case 3: More chunks than elements
     list_to_divide: list[int] = [1, 2]
     n: int = 3
-    expected_output: list[list[int]] = [[1], [2]]
+    expected_output: list[list[int]] = [[1], [2], []]
     assert divide_list_into_n_chunks(list_to_divide, n) == expected_output
 
 
@@ -42,7 +42,7 @@ def test_divide_list_into_n_chunks_empty_list() -> None:
     # Test case 4: Empty list
     list_to_divide: list[int] = []
     n: int = 3
-    expected_output: list[list[int]] = []
+    expected_output: list[list[int]] = [[], [], []]
     assert divide_list_into_n_chunks(list_to_divide, n) == expected_output
 
 


### PR DESCRIPTION
## Summary
- ensure `divide_list_into_n_chunks` returns exactly `n` sublists even when some are empty
- document behavior and examples for cases where `n` exceeds the list length
- adjust tests to expect empty placeholder sublists when required

## Testing
- `pytest pytest/unit/iterable_functions/test_divide_list_into_n_chunks.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68938e093bb48325afb7dfcaa7e8949f