### PR TITLE
Validate non-negative repeats in repeat_string

### DIFF
--- a/pytest/unit/strings_utility/test_repeat_string.py
+++ b/pytest/unit/strings_utility/test_repeat_string.py
@@ -33,7 +33,8 @@ def test_repeat_string_negative_times() -> None:
     Test the repeat_string function with a string repeated negative times.
     """
     # Test case 4: Repeat a string negative times
-    assert repeat_string("hello", -1) == "", "Failed on repeating string negative times"
+    with pytest.raises(ValueError):
+        repeat_string("hello", -1)
 
 
 def test_repeat_string_empty_string() -> None:

--- a/strings_utility/repeat_string.py
+++ b/strings_utility/repeat_string.py
@@ -7,7 +7,7 @@ def repeat_string(s: str, n: int) -> str:
     s : str
         The input string.
     n : int
-        The number of times to repeat the string.
+        The number of times to repeat the string. Must be non-negative.
 
     Returns
     -------
@@ -18,6 +18,8 @@ def repeat_string(s: str, n: int) -> str:
     ------
     TypeError
         If the input string is not a string or the number of times is not an integer.
+    ValueError
+        If the number of times is negative.
 
     Examples
     --------
@@ -28,12 +30,16 @@ def repeat_string(s: str, n: int) -> str:
     >>> repeat_string("test", 0)
     ''
     >>> repeat_string("repeat", -1)
-    ''
+    Traceback (most recent call last):
+        ...
+    ValueError: The number of times must be non-negative.
     """
     if not isinstance(s, str):
         raise TypeError("The input string must be a string.")
     if not isinstance(n, int):
         raise TypeError("The number of times must be an integer.")
+    if n < 0:
+        raise ValueError("The number of times must be non-negative.")
     return s * n
 
 __all__ = ['repeat_string']


### PR DESCRIPTION
## Summary
- Raise `ValueError` when `repeat_string` receives a negative count
- Document non-negative requirement and update examples
- Adjust unit test to expect `ValueError`

## Testing
- `pytest -q`
- `pytest pytest/unit/strings_utility/test_repeat_string.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68938e0a7314832584b329b0b9977c71