### PR TITLE
Add tests for get_paths_dict utility

### DIFF
--- a/pytest/unit/file_functions/test_get_paths_dict.py
+++ b/pytest/unit/file_functions/test_get_paths_dict.py
@@ -1,0 +1,51 @@
+import os
+import pytest
+from file_functions.get_paths_dict import get_paths_dict
+
+
+def test_get_paths_dict_files_only(tmp_path) -> None:
+    """Test retrieving only files from a directory containing files and folders."""
+    (tmp_path / "file1.txt").write_text("a")
+    (tmp_path / "file2.log").write_text("b")
+    (tmp_path / "folder").mkdir()
+
+    expected_paths: dict[str, str] = {
+        "file1.txt": os.path.join(tmp_path, "file1.txt"),
+        "file2.log": os.path.join(tmp_path, "file2.log"),
+    }
+    returned_paths: dict[str, str] = get_paths_dict(str(tmp_path), "files")
+    assert returned_paths == expected_paths, "Should return only file paths"
+
+
+def test_get_paths_dict_directories_only(tmp_path) -> None:
+    """Test retrieving only directories from a directory containing files and folders."""
+    (tmp_path / "file.txt").write_text("a")
+    folder_path = tmp_path / "folder"
+    folder_path.mkdir()
+
+    returned_paths: dict[str, str] = get_paths_dict(str(tmp_path), "directories")
+    expected_paths: dict[str, str] = {"folder": os.path.join(tmp_path, "folder")}
+    assert returned_paths == expected_paths, "Should return only directory paths"
+
+
+def test_get_paths_dict_all_items(tmp_path) -> None:
+    """Test retrieving all items (files and directories) from a directory."""
+    (tmp_path / "file.txt").write_text("a")
+    (tmp_path / "folder").mkdir()
+
+    expected_paths: dict[str, str] = {
+        "file.txt": os.path.join(tmp_path, "file.txt"),
+        "folder": os.path.join(tmp_path, "folder"),
+    }
+    returned_paths: dict[str, str] = get_paths_dict(str(tmp_path), "all")
+    assert returned_paths == expected_paths, "Should return files and directories"
+
+
+def test_get_paths_dict_errors(tmp_path) -> None:
+    """Test error handling for invalid type and missing directory."""
+    with pytest.raises(ValueError):
+        get_paths_dict(str(tmp_path), "invalid")
+
+    missing_dir: str = os.path.join(str(tmp_path), "missing")
+    with pytest.raises(FileNotFoundError):
+        get_paths_dict(missing_dir, "files")


### PR DESCRIPTION
## Summary
- add unit tests for `get_paths_dict` to cover files, directories, and all items
- ensure invalid type and missing directory raise appropriate errors

## Testing
- `pytest pytest/unit/file_functions/test_get_paths_dict.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689753905a8c83259c9c0a6f85da0038