### PR TITLE
Add unit tests for read_lines utility

### DIFF
--- a/pytest/unit/file_functions/test_read_lines.py
+++ b/pytest/unit/file_functions/test_read_lines.py
@@ -1,0 +1,36 @@
+import pytest
+from file_functions.read_lines import read_lines
+
+
+def test_read_lines_entire_file_with_stripping(tmp_path) -> None:
+    """Test reading entire file with default stripping."""
+    file_path = tmp_path / "input.txt"
+    file_path.write_text("  line1  \nline2\n line3 ")
+    expected: list[str] = ["line1", "line2", "line3"]
+    returned: list[str] = read_lines(str(file_path))
+    assert returned == expected, "Should read all lines stripped of whitespace"
+
+
+def test_read_lines_limited_num_lines(tmp_path) -> None:
+    """Test reading only a limited number of lines."""
+    file_path = tmp_path / "input.txt"
+    file_path.write_text("line1\nline2\nline3\n")
+    returned: list[str] = read_lines(str(file_path), num_lines=2)
+    expected: list[str] = ["line1", "line2"]
+    assert returned == expected, "Should return the first num_lines lines"
+
+
+def test_read_lines_strip_false(tmp_path) -> None:
+    """Test that setting strip=False preserves whitespace."""
+    file_path = tmp_path / "input.txt"
+    file_path.write_text("  line1  \nline2\n")
+    returned: list[str] = read_lines(str(file_path), strip=False)
+    expected: list[str] = ["  line1  \n", "line2\n"]
+    assert returned == expected, "Should preserve whitespace when strip=False"
+
+
+def test_read_lines_missing_file(tmp_path) -> None:
+    """Test that a missing file raises FileNotFoundError."""
+    missing_file = tmp_path / "missing.txt"
+    with pytest.raises(FileNotFoundError):
+        read_lines(str(missing_file))


### PR DESCRIPTION
## Summary
- add unit tests for `read_lines` covering full file reads, limiting lines, whitespace handling, and missing file errors

## Testing
- `pytest pytest/unit/file_functions/test_read_lines.py`


------
https://chatgpt.com/codex/tasks/task_e_689753948ef8832580b00a7896306632