### PR TITLE
Improve file_basename and add tests

### DIFF
--- a/file_functions/file_basename.py
+++ b/file_functions/file_basename.py
@@ -16,10 +16,22 @@ def file_basename(file_path: str, file_extension: bool = True) -> str:
     -------
     str
         The file name extracted from the file path.
-    """
-    if not file_extension:
-        return os.path.basename(file_path).split(".")[0]
-    else:
-        return os.path.basename(file_path)
 
-__all__ = ['file_basename']
+    Raises
+    ------
+    ValueError
+        If ``file_path`` is an empty string.
+    """
+    if not file_path:
+        raise ValueError("file_path must not be empty")
+
+    normalized_path: str = file_path.rstrip(os.sep)
+    base_name: str = os.path.basename(normalized_path)
+
+    if not file_extension:
+        base_name = os.path.splitext(base_name)[0]
+
+    return base_name
+
+
+__all__ = ["file_basename"]

--- a/pytest/unit/file_functions/test_file_basename.py
+++ b/pytest/unit/file_functions/test_file_basename.py
@@ -1,0 +1,46 @@
+import pytest
+
+from file_functions.file_basename import file_basename
+
+
+def test_file_basename_default_mode() -> None:
+    """Test that the default mode returns the filename with extension."""
+    path: str = "/path/to/example.txt"
+    assert (
+        file_basename(path) == "example.txt"
+    ), "Should return filename with extension"
+
+
+def test_file_basename_strip_extension() -> None:
+    """Test that setting ``file_extension`` to ``False`` strips the extension."""
+    path: str = "/path/to/example.txt"
+    assert (
+        file_basename(path, file_extension=False) == "example"
+    ), "Should remove the extension"
+
+
+def test_file_basename_multiple_dots() -> None:
+    """Test handling filenames that contain multiple dots."""
+    path: str = "/path/to/archive.tar.gz"
+    assert file_basename(path) == "archive.tar.gz"
+    assert (
+        file_basename(path, file_extension=False) == "archive.tar"
+    ), "Should remove only the last extension"
+
+
+def test_file_basename_trailing_slash() -> None:
+    """Test handling paths that include a trailing slash."""
+    path: str = "/path/to/file.txt/"
+    assert (
+        file_basename(path) == "file.txt"
+    ), "Should handle trailing slash correctly"
+    assert (
+        file_basename(path, file_extension=False) == "file"
+    ), "Should handle trailing slash and remove extension"
+
+
+def test_file_basename_empty_path_raises_value_error() -> None:
+    """Test that providing an empty path raises a ``ValueError``."""
+    with pytest.raises(ValueError):
+        file_basename("")
+


### PR DESCRIPTION
## Summary
- raise `ValueError` when `file_basename` receives an empty path
- handle trailing slashes and use `splitext` so only the last extension is removed
- add tests for default behavior, extension stripping, multi-dot names, trailing slash handling, and empty path errors

## Testing
- `pytest pytest/unit/file_functions/test_file_basename.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6897538f0ef48325b703a913114a0330