### PR TITLE
test: ensure create_directory handles file paths

### DIFF
--- a/pytest/unit/file_functions/test_create_directory.py
+++ b/pytest/unit/file_functions/test_create_directory.py
@@ -20,6 +20,15 @@ def test_existing_directory(tmp_path) -> None:
     assert result is False, "Should return False if directory already exists"
 
 
+def test_path_is_existing_file(tmp_path) -> None:
+    """Calling on a path that points to a file should return False and keep the file."""
+    file_path = tmp_path / "target"
+    file_path.write_text("data")
+    result: bool = create_directory(str(file_path))
+    assert result is False, "Should return False if path already exists as a file"
+    assert file_path.exists(), "Existing file should remain after call"
+
+
 def test_nested_path_creation(tmp_path) -> None:
     """Creating nested directories should succeed."""
     nested_dir = tmp_path / "level1" / "level2" / "level3"


### PR DESCRIPTION
## Summary
- add regression test verifying `create_directory` returns False when path exists as a file and leaves file intact

## Testing
- `pytest pytest/unit/file_functions`

------
https://chatgpt.com/codex/tasks/task_e_68988e2ef76883258b310b1c914de4cf