### PR TITLE
Handle non-positive num_lines in read_lines

### DIFF
--- a/file_functions/read_lines.py
+++ b/file_functions/read_lines.py
@@ -24,6 +24,8 @@ def read_lines(
     with open(input_file) as infile:
         if num_lines is None:
             lines: list[str] = [line for line in infile.readlines()]
+        elif num_lines <= 0:
+            lines = []
         else:
             lines = list(islice(infile, num_lines))
 

--- a/pytest/unit/file_functions/test_read_lines.py
+++ b/pytest/unit/file_functions/test_read_lines.py
@@ -34,3 +34,21 @@ def test_read_lines_missing_file(tmp_path) -> None:
     missing_file = tmp_path / "missing.txt"
     with pytest.raises(FileNotFoundError):
         read_lines(str(missing_file))
+
+
+def test_read_lines_zero_num_lines(tmp_path) -> None:
+    """Test that providing num_lines=0 returns an empty list."""
+    file_path = tmp_path / "input.txt"
+    file_path.write_text("line1\nline2\n")
+    returned: list[str] = read_lines(str(file_path), num_lines=0)
+    expected: list[str] = []
+    assert returned == expected, "Should return an empty list when num_lines is 0"
+
+
+def test_read_lines_negative_num_lines(tmp_path) -> None:
+    """Test that providing a negative num_lines returns an empty list."""
+    file_path = tmp_path / "input.txt"
+    file_path.write_text("line1\nline2\n")
+    returned: list[str] = read_lines(str(file_path), num_lines=-1)
+    expected: list[str] = []
+    assert returned == expected, "Should return an empty list when num_lines is negative"


### PR DESCRIPTION
## Summary
- ensure `read_lines` returns an empty list when `num_lines` is 0 or negative
- test `read_lines` with zero and negative `num_lines`

## Testing
- `pytest pytest/unit/file_functions`


------
https://chatgpt.com/codex/tasks/task_e_68988e2f5f388325bec0d5df21a25f0b