### PR TITLE
Add test for empty write_lines input

### DIFF
--- a/pytest/unit/file_functions/test_write_functions.py
+++ b/pytest/unit/file_functions/test_write_functions.py
@@ -12,6 +12,13 @@ def test_write_lines_default_joiner(tmp_path) -> None:
     assert out_file.read_text() == "one\ntwo\nthree\n"
 
 
+def test_write_lines_empty_list(tmp_path) -> None:
+    """Writing an empty list results in a file with only a newline."""
+    out_file = tmp_path / "out.txt"
+    write_lines([], str(out_file))
+    assert out_file.read_text() == "\n"
+
+
 def test_write_lines_custom_joiner_append(tmp_path) -> None:
     """Use custom joiner and append mode."""
     out_file = tmp_path / "out.txt"


### PR DESCRIPTION
## Summary
- test that `write_lines` writes a newline when given an empty list

## Testing
- `pytest pytest/unit/file_functions`


------
https://chatgpt.com/codex/tasks/task_e_68988e3282088325b2567fd3ad7d2712