### PR TITLE
test: tidy imports in read_tabular test

### DIFF
--- a/pytest/unit/file_functions/test_read_tabular.py
+++ b/pytest/unit/file_functions/test_read_tabular.py
@@ -1,4 +1,3 @@
-import pytest
 from pathlib import Path
 
 import pytest


### PR DESCRIPTION
## Summary
- order imports in test_read_tabular to standard/third-party/local
- drop duplicated pytest import

## Testing
- `pytest pytest/unit/file_functions/test_read_tabular.py`

------
https://chatgpt.com/codex/tasks/task_e_689896f759fc832581017fc3e8030032