### PR TITLE
chore: tidy file_functions test imports

### DIFF
--- a/pytest/unit/file_functions/test_get_paths_dict.py
+++ b/pytest/unit/file_functions/test_get_paths_dict.py
@@ -1,5 +1,4 @@
 import os
-import os
 from pathlib import Path
 
 import pytest

--- a/pytest/unit/file_functions/test_get_paths_in_directory_with_suffix.py
+++ b/pytest/unit/file_functions/test_get_paths_in_directory_with_suffix.py
@@ -1,5 +1,4 @@
 import os
-import os
 from pathlib import Path
 
 import pytest

--- a/pytest/unit/file_functions/test_join_paths.py
+++ b/pytest/unit/file_functions/test_join_paths.py
@@ -1,5 +1,4 @@
 import os
-import os
 from pathlib import Path
 
 import pytest

--- a/pytest/unit/file_functions/test_read_tabular.py
+++ b/pytest/unit/file_functions/test_read_tabular.py
@@ -1,4 +1,3 @@
-import pytest
 from pathlib import Path
 
 import pytest

--- a/pytest/unit/file_functions/test_write_functions.py
+++ b/pytest/unit/file_functions/test_write_functions.py
@@ -1,5 +1,3 @@
-import pytest
-
 from pathlib import Path
 
 import pytest


### PR DESCRIPTION
## Summary
- remove duplicate imports in file_functions tests
- group imports by standard library, third-party, and local modules

## Testing
- `pytest pytest/unit/file_functions/test_get_paths_dict.py pytest/unit/file_functions/test_get_paths_in_directory_with_suffix.py pytest/unit/file_functions/test_join_paths.py pytest/unit/file_functions/test_read_tabular.py pytest/unit/file_functions/test_write_functions.py`

------
https://chatgpt.com/codex/tasks/task_e_689896f5b0208325a41f310d47972def