### PR TITLE
Handle unhashable sublists with ValueError

### DIFF
--- a/iterable_functions/get_unique_sublists.py
+++ b/iterable_functions/get_unique_sublists.py
@@ -30,13 +30,13 @@ def get_unique_sublists(list_of_lists: list[list[Any]]) -> list[list[Any]]:
     seen = set()
     unique_sublists = []
     for sublist in list_of_lists:
+        sublist_tuple = tuple(sublist)
         try:
-            sublist_tuple = tuple(sublist)
+            if sublist_tuple not in seen:
+                seen.add(sublist_tuple)
+                unique_sublists.append(sublist)
         except TypeError as e:
-            raise TypeError(f"Sublist contains unhashable elements: {e}")
-        if sublist_tuple not in seen:
-            seen.add(sublist_tuple)
-            unique_sublists.append(sublist)
+            raise ValueError(f"Sublist contains unhashable elements: {e}") from e
     return unique_sublists
 
 __all__ = ['get_unique_sublists']

--- a/pytest/unit/iterable_functions/test_get_unique_sublists.py
+++ b/pytest/unit/iterable_functions/test_get_unique_sublists.py
@@ -90,5 +90,5 @@ def test_get_unique_sublists_unhashable_elements() -> None:
     Test the get_unique_sublists function with unhashable elements in sublists.
     """
     # Test case 9: Unhashable elements in sublists
-    with pytest.raises(TypeError):
+    with pytest.raises(ValueError):
         get_unique_sublists([[1, 2], [{3: 4}, 5]])


### PR DESCRIPTION
## Summary
- raise `ValueError` when `get_unique_sublists` encounters unhashable sublist elements
- adjust unit tests to expect `ValueError`

## Testing
- `pytest pytest/unit/iterable_functions/test_get_unique_sublists.py`

------
https://chatgpt.com/codex/tasks/task_e_689e29a04f1c83258a683db9391fe80b