### PR TITLE
Add platform import in system info printer

### DIFF
--- a/print_functions/print_system_info_in_terminal.py
+++ b/print_functions/print_system_info_in_terminal.py
@@ -1,8 +1,9 @@
 import platform
-import psutil
 import shutil
 import subprocess
 import time
+
+import psutil
 
 from print_functions.print_message import print_message
 


### PR DESCRIPTION
## Summary
- reorder imports and ensure `platform` is imported in `print_system_info_in_terminal`

## Testing
- `pytest pytest/unit/print_functions/test_print_system_info_in_terminal.py` *(fails: file or directory not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e29a12dac8325b6481b6031044eeb