### PR TITLE
Refactor BinaryHeap to use priority-value tuples

### DIFF
--- a/pytest/unit/data_types/test_BinaryHeap.py
+++ b/pytest/unit/data_types/test_BinaryHeap.py
@@ -1,3 +1,4 @@
+
 import pytest
 from data_types.binary_heap import BinaryHeap
 
@@ -12,7 +13,7 @@ def test_insert_min_heap() -> None:
     heap.insert(5)
     heap.insert(20)
     heap.insert(1)
-    assert heap.heap == [1, 5, 20, 10]  # Min-heap property should be maintained
+    assert heap.heap == [(1, 1), (5, 5), (20, 20), (10, 10)]  # Min-heap property should be maintained
 
 
 def test_insert_max_heap() -> None:
@@ -25,7 +26,7 @@ def test_insert_max_heap() -> None:
     heap.insert(5)
     heap.insert(20)
     heap.insert(1)
-    assert heap.heap == [-20, -5, -10, -1]  # Internal representation uses negatives
+    assert heap.heap == [(20, 20), (5, 5), (10, 10), (1, 1)]  # Internal representation uses max-heap
 
 
 def test_extract_min_heap() -> None:
@@ -40,7 +41,7 @@ def test_extract_min_heap() -> None:
     heap.insert(1)
     root = heap.extract()
     assert root == 1  # Root should be the smallest element
-    assert heap.heap == [5, 10, 20]  # Heap property should be maintained
+    assert heap.heap == [(5, 5), (10, 10), (20, 20)]  # Heap property should be maintained
 
 
 def test_extract_max_heap() -> None:
@@ -55,7 +56,7 @@ def test_extract_max_heap() -> None:
     heap.insert(1)
     root = heap.extract()
     assert root == 20  # Root should be the largest element
-    assert heap.heap == [-10, -5, -1]  # Internal representation after extraction
+    assert heap.heap == [(10, 10), (5, 5), (1, 1)]  # Internal representation after extraction
 
 
 def test_insert_and_extract_min_heap() -> None:
@@ -128,7 +129,7 @@ def test_insert_duplicate_elements_min_heap() -> None:
     heap.insert(10)
     heap.insert(5)
     heap.insert(5)
-    assert heap.heap == [5, 5, 10, 10]  # Min-heap property should be maintained
+    assert heap.heap == [(5, 5), (5, 5), (10, 10), (10, 10)]  # Min-heap property should be maintained
 
 
 def test_insert_duplicate_elements_max_heap() -> None:
@@ -141,7 +142,7 @@ def test_insert_duplicate_elements_max_heap() -> None:
     heap.insert(10)
     heap.insert(20)
     heap.insert(20)
-    assert heap.heap == [-20, -20, -10, -10]  # Internal representation uses negatives
+    assert heap.heap == [(20, 20), (20, 20), (10, 10), (10, 10)]  # Internal representation uses max-heap
 
 
 def test_insert_boundary_values() -> None:
@@ -173,9 +174,9 @@ def test_heapify_min_heap() -> None:
     """
     # Test case 13: Heapify a list into a min-heap
     heap = BinaryHeap[int](is_min_heap=True)
-    heap.heap = [10, 5, 20, 1]
+    heap.heap = [(10, 10), (5, 5), (20, 20), (1, 1)]
     heap.heapify()
-    assert heap.heap == [1, 5, 20, 10]  # Min-heap property should be maintained
+    assert heap.heap == [(1, 1), (5, 5), (20, 20), (10, 10)]  # Min-heap property should be maintained
 
 
 def test_heapify_max_heap() -> None:
@@ -184,9 +185,9 @@ def test_heapify_max_heap() -> None:
     """
     # Test case 14: Heapify a list into a max-heap
     heap = BinaryHeap[int](is_min_heap=False)
-    heap.heap = [10, 5, 20, 1]
+    heap.heap = [(10, 10), (5, 5), (20, 20), (1, 1)]
     heap.heapify()
-    assert heap.heap == [-20, -5, -10, -1]  # Internal representation uses negatives
+    assert heap.heap == [(20, 20), (5, 5), (10, 10), (1, 1)]  # Internal representation uses max-heap
 
 
 def test_extract_from_empty_heap() -> None:
@@ -197,3 +198,25 @@ def test_extract_from_empty_heap() -> None:
     heap = BinaryHeap[int](is_min_heap=True)
     with pytest.raises(IndexError):
         heap.extract()  # Should raise an IndexError
+
+
+def test_non_numeric_min_heap() -> None:
+    """Ensure heap handles non-numeric values in a min-heap."""
+    heap = BinaryHeap[str](is_min_heap=True)
+    heap.insert("banana", priority=2)
+    heap.insert("apple", priority=1)
+    heap.insert("cherry", priority=3)
+    assert heap.extract() == "apple"
+    assert heap.extract() == "banana"
+    assert heap.extract() == "cherry"
+
+
+def test_non_numeric_max_heap() -> None:
+    """Ensure heap handles non-numeric values in a max-heap."""
+    heap = BinaryHeap[str](is_min_heap=False)
+    heap.insert("banana", priority=2)
+    heap.insert("apple", priority=1)
+    heap.insert("cherry", priority=3)
+    assert heap.extract() == "cherry"
+    assert heap.extract() == "banana"
+    assert heap.extract() == "apple"


### PR DESCRIPTION
## Summary
- store heap entries as `(priority, value)` pairs
- support max-heap via heapq max helpers instead of negation
- test BinaryHeap with non-numeric values

## Testing
- `pytest pytest/unit/data_types/test_BinaryHeap.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e29a21c6c832588366fd654e7ba51