### PR TITLE
Add membership dunder to HashTable

### DIFF
--- a/data_types/hash_table.py
+++ b/data_types/hash_table.py
@@ -139,3 +139,10 @@ class HashTable(Generic[K, V]):
             if k == key:
                 return True
         return False
+
+    def __contains__(self, key: K) -> bool:
+        """Check if *key* exists in the table."""
+        return self.contains(key)
+
+
+__all__ = ["HashTable"]

--- a/pytest/unit/data_types/test_HashTable.py
+++ b/pytest/unit/data_types/test_HashTable.py
@@ -163,3 +163,12 @@ def test_remove_nonexistent_key() -> None:
     hash_table = HashTable[int, str]()
     with pytest.raises(KeyError, match="Key 1 not found in the hash table"):
         hash_table.remove(1)
+
+
+def test_in_operator() -> None:
+    """Test using the ``in`` operator with :class:`HashTable`."""
+    # Test case 13: ``in`` operator usage
+    hash_table = HashTable[int, str]()
+    hash_table.insert(1, "one")
+    assert (1 in hash_table) is True
+    assert (2 in hash_table) is False


### PR DESCRIPTION
## Summary
- support `in` operator by delegating `HashTable.__contains__` to `contains`
- export `HashTable` through module `__all__`
- add unit test verifying `key in HashTable` usage

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4cfdceddc8325b370516bb6018152