### PR TITLE
feat: allow async rate limited iterables

### DIFF
--- a/asyncio_functions/async_rate_limited.py
+++ b/asyncio_functions/async_rate_limited.py
@@ -1,5 +1,5 @@
 from typing import TypeVar
-from collections.abc import Callable, Awaitable
+from collections.abc import Callable, Awaitable, Iterable
 from collections import deque
 import asyncio
 import time
@@ -10,7 +10,7 @@ R = TypeVar("R")
 
 async def async_rate_limited(
     func: Callable[[T], Awaitable[R]],
-    items: list[T],
+    items: Iterable[T],
     max_calls: int,
     period: float = 1.0,
 ) -> list[R]:
@@ -20,8 +20,8 @@ async def async_rate_limited(
     ----------
     func : Callable[[T], Awaitable[R]]
         The asynchronous function to apply to each item.
-    items : list[T]
-        The list of items to process.
+    items : Iterable[T]
+        The iterable of items to process.
     max_calls : int
         Maximum number of calls allowed within the given period.
     period : float, optional

--- a/pytest/unit/asyncio_functions/test_async_rate_limited.py
+++ b/pytest/unit/asyncio_functions/test_async_rate_limited.py
@@ -20,6 +20,31 @@ async def test_async_rate_limited_success() -> None:
 
 
 @pytest.mark.asyncio
+async def test_async_rate_limited_tuple() -> None:
+    """Test processing a tuple of items."""
+    start = time.monotonic()
+    result = await async_rate_limited(echo, (1, 2, 3), max_calls=2, period=1.0)
+    elapsed = time.monotonic() - start
+    assert result == [1, 2, 3]
+    assert elapsed >= 1.0
+
+
+def generate_numbers():
+    for i in range(3):
+        yield i
+
+
+@pytest.mark.asyncio
+async def test_async_rate_limited_generator() -> None:
+    """Test processing items from a generator."""
+    start = time.monotonic()
+    result = await async_rate_limited(echo, generate_numbers(), max_calls=2, period=1.0)
+    elapsed = time.monotonic() - start
+    assert result == [0, 1, 2]
+    assert elapsed >= 1.0
+
+
+@pytest.mark.asyncio
 async def test_async_rate_limited_invalid_params() -> None:
     """Test invalid parameters raise ValueError."""
     with pytest.raises(ValueError):


### PR DESCRIPTION
## Summary
- expand async_rate_limited to accept any iterable of items
- add tests for tuple and generator inputs

## Testing
- `pytest pytest/unit/asyncio_functions/test_async_rate_limited.py`


------
https://chatgpt.com/codex/tasks/task_e_68a4cfd9fc1c8325ac9ba55b098edf25