### PR TITLE
chore: remove unused pytest imports

### DIFF
--- a/pytest/unit/multiprocessing_functions/test_parallel_accumulate.py
+++ b/pytest/unit/multiprocessing_functions/test_parallel_accumulate.py
@@ -1,4 +1,3 @@
-import pytest
 from multiprocessing_functions.parallel_accumulate import parallel_accumulate
 
 

--- a/pytest/unit/multiprocessing_functions/test_parallel_apply_with_args.py
+++ b/pytest/unit/multiprocessing_functions/test_parallel_apply_with_args.py
@@ -1,4 +1,3 @@
-import pytest
 from multiprocessing_functions.parallel_apply_with_args import parallel_apply_with_args
 
 

--- a/pytest/unit/multiprocessing_functions/test_parallel_broadcast.py
+++ b/pytest/unit/multiprocessing_functions/test_parallel_broadcast.py
@@ -1,4 +1,3 @@
-import pytest
 from multiprocessing_functions.parallel_broadcast import parallel_broadcast
 
 

--- a/pytest/unit/multiprocessing_functions/test_parallel_dynamic_distribute.py
+++ b/pytest/unit/multiprocessing_functions/test_parallel_dynamic_distribute.py
@@ -1,4 +1,3 @@
-import pytest
 from multiprocessing_functions.parallel_dynamic_distribute import (
     parallel_dynamic_distribute,
 )

--- a/pytest/unit/multiprocessing_functions/test_parallel_filter.py
+++ b/pytest/unit/multiprocessing_functions/test_parallel_filter.py
@@ -1,4 +1,3 @@
-import pytest
 from multiprocessing_functions.parallel_filter import parallel_filter
 
 

--- a/pytest/unit/multiprocessing_functions/test_parallel_gather_errors.py
+++ b/pytest/unit/multiprocessing_functions/test_parallel_gather_errors.py
@@ -1,4 +1,3 @@
-import pytest
 from multiprocessing_functions.parallel_gather_errors import parallel_gather_errors
 
 

--- a/pytest/unit/multiprocessing_functions/test_parallel_map.py
+++ b/pytest/unit/multiprocessing_functions/test_parallel_map.py
@@ -1,4 +1,3 @@
-import pytest
 from multiprocessing_functions.parallel_map import parallel_map
 
 

--- a/pytest/unit/multiprocessing_functions/test_parallel_pipeline.py
+++ b/pytest/unit/multiprocessing_functions/test_parallel_pipeline.py
@@ -1,4 +1,3 @@
-import pytest
 from multiprocessing_functions.parallel_pipeline import parallel_pipeline
 
 

--- a/pytest/unit/multiprocessing_functions/test_parallel_progress_bar.py
+++ b/pytest/unit/multiprocessing_functions/test_parallel_progress_bar.py
@@ -1,4 +1,3 @@
-import pytest
 from multiprocessing_functions.parallel_progress_bar import parallel_progress_bar
 
 

--- a/pytest/unit/multiprocessing_functions/test_parallel_reduce.py
+++ b/pytest/unit/multiprocessing_functions/test_parallel_reduce.py
@@ -1,4 +1,3 @@
-import pytest
 from multiprocessing_functions.parallel_reduce import parallel_reduce
 
 

--- a/pytest/unit/multiprocessing_functions/test_parallel_sort.py
+++ b/pytest/unit/multiprocessing_functions/test_parallel_sort.py
@@ -1,4 +1,3 @@
-import pytest
 from multiprocessing_functions.parallel_sort import parallel_sort
 
 

--- a/pytest/unit/multiprocessing_functions/test_parallel_starmap.py
+++ b/pytest/unit/multiprocessing_functions/test_parallel_starmap.py
@@ -1,4 +1,3 @@
-import pytest
 from multiprocessing_functions.parallel_starmap import parallel_starmap
 
 

--- a/pytest/unit/multiprocessing_functions/test_parallel_sum.py
+++ b/pytest/unit/multiprocessing_functions/test_parallel_sum.py
@@ -1,4 +1,3 @@
-import pytest
 from multiprocessing_functions.parallel_sum import parallel_sum
 
 

--- a/pytest/unit/multiprocessing_functions/test_parallel_unique.py
+++ b/pytest/unit/multiprocessing_functions/test_parallel_unique.py
@@ -1,4 +1,3 @@
-import pytest
 from multiprocessing_functions.parallel_unique import parallel_unique
 
 


### PR DESCRIPTION
## Summary
- remove unnecessary `pytest` imports from multiprocessing tests

## Testing
- `pytest pytest/unit/multiprocessing_functions/test_parallel_accumulate.py -q`
- `pytest pytest/unit/multiprocessing_functions/test_parallel_progress_bar.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4d30884c08325a6572486fecd4723