### PR TITLE
compile regex once for identify_string_in_dict_lists_regex

### DIFF
--- a/iterable_functions/identify_string_in_dict_lists_regex.py
+++ b/iterable_functions/identify_string_in_dict_lists_regex.py
@@ -4,8 +4,8 @@ import re
 def identify_string_in_dict_lists_regex(
     target_value: str,
     dict_of_lists: dict[str | int, list[list[str]]],
-    regex: str = None,
-) -> str | int | bool:
+    regex: str | None = None,
+) -> str | int | None:
     """
     Identifies if a string is present in any list inside a dictionary.
 
@@ -15,13 +15,13 @@ def identify_string_in_dict_lists_regex(
         The value to find.
     dict_of_lists : dict
         A dictionary where the values are lists of lists.
-    regex : str, optional
+    regex : str | None, optional
         A regex pattern to search for in the lists.
 
     Returns
     -------
-    int or str or bool
-        The key of the entry where the string is present, or False if not found.
+    int or str or None
+        The key of the entry where the string is present, or None if not found.
 
     Raises
     ------
@@ -40,14 +40,16 @@ def identify_string_in_dict_lists_regex(
     if regex is not None and not isinstance(regex, str):
         raise TypeError("regex must be a string or None")
 
+    compiled_regex = re.compile(regex) if regex else None
+
     for key, lists in dict_of_lists.items():
         for list_ in lists:
-            if regex:
-                if any(re.search(regex, item) for item in list_):
+            if compiled_regex:
+                if any(compiled_regex.search(item) for item in list_):
                     return key
             else:
                 if target_value in list_:
                     return key
-    return False
+    return None
 
 __all__ = ['identify_string_in_dict_lists_regex']

--- a/pytest/unit/iterable_functions/test_identify_string_in_dict_lists_regex.py
+++ b/pytest/unit/iterable_functions/test_identify_string_in_dict_lists_regex.py
@@ -31,7 +31,7 @@ def test_identify_string_in_dict_lists_regex_not_found() -> None:
         "key2": [["fig", "grape"], ["kiwi", "lemon"]],
     }
     target_value: str = "orange"
-    expected_output: bool = False
+    expected_output = None
     assert (
         identify_string_in_dict_lists_regex(target_value, dict_of_lists)
         == expected_output
@@ -45,7 +45,7 @@ def test_identify_string_in_dict_lists_regex_empty_dict() -> None:
     # Test case 3: Empty dictionary
     dict_of_lists: dict[str | int, list[list[str]]] = {}
     target_value: str = "apple"
-    expected_output: bool = False
+    expected_output = None
     assert (
         identify_string_in_dict_lists_regex(target_value, dict_of_lists)
         == expected_output


### PR DESCRIPTION
## Summary
- compile provided regex once before iterating over dictionary
- return `None` instead of `False` when no match is found and update tests

## Testing
- `pytest pytest/unit/iterable_functions/test_identify_string_in_dict_lists_regex.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4cfdbae54832590b61edcbef81ad3