### PR TITLE
Add DataFrame to dict utility and tests

### DIFF
--- a/pandas_functions/__init__.py
+++ b/pandas_functions/__init__.py
@@ -1,7 +1,9 @@
 from .dict_to_df import dict_to_df
 from .import_df_from_file import import_df_from_file
+from .df_to_dict import df_to_dict
 
 __all__ = [
     "dict_to_df",
     "import_df_from_file",
+    "df_to_dict",
 ]

--- a/pandas_functions/df_to_dict.py
+++ b/pandas_functions/df_to_dict.py
@@ -1,0 +1,30 @@
+import pandas as pd
+
+
+def df_to_dict(df: pd.DataFrame, orient: str = "dict") -> dict:
+    """
+    Convert a pandas DataFrame to a dictionary using ``DataFrame.to_dict``.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        DataFrame to convert.
+    orient : str, optional
+        Orientation of the resulting dictionary, by default ``"dict"``.
+
+    Returns
+    -------
+    dict
+        Dictionary representation of the DataFrame.
+
+    Raises
+    ------
+    TypeError
+        If ``df`` is not a pandas DataFrame.
+    """
+    if not isinstance(df, pd.DataFrame):
+        raise TypeError("df must be a pandas DataFrame")
+    return df.to_dict(orient=orient)
+
+
+__all__ = ["df_to_dict"]

--- a/pytest/unit/pandas_functions/test_df_to_dict.py
+++ b/pytest/unit/pandas_functions/test_df_to_dict.py
@@ -1,0 +1,24 @@
+import pandas as pd
+import pytest
+
+from pandas_functions.df_to_dict import df_to_dict
+
+
+def test_df_to_dict_default() -> None:
+    """DataFrame should convert to nested dict with default orientation."""
+    df: pd.DataFrame = pd.DataFrame({"col1": [1, 2], "col2": [3, 4]})
+    expected: dict = {"col1": {0: 1, 1: 2}, "col2": {0: 3, 1: 4}}
+    assert df_to_dict(df) == expected
+
+
+def test_df_to_dict_list_orient() -> None:
+    """DataFrame should convert to list-oriented dictionary."""
+    df: pd.DataFrame = pd.DataFrame({"col1": [1, 2], "col2": [3, 4]})
+    expected: dict = {"col1": [1, 2], "col2": [3, 4]}
+    assert df_to_dict(df, orient="list") == expected
+
+
+def test_df_to_dict_invalid_input() -> None:
+    """Passing a non-DataFrame should raise a TypeError."""
+    with pytest.raises(TypeError):
+        df_to_dict({"col1": [1, 2]})


### PR DESCRIPTION
## Summary
- add `df_to_dict` for converting DataFrames into dictionaries with optional orientation
- expose new helper in `pandas_functions` package
- test default, list-oriented, and invalid-input scenarios

## Testing
- `pytest pytest/unit/pandas_functions/test_df_to_dict.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5f185759c8325a867f0ecd14d7d23