### PR TITLE
Add merge_dataframes helper and tests

### DIFF
--- a/pandas_functions/__init__.py
+++ b/pandas_functions/__init__.py
@@ -1,7 +1,9 @@
 from .dict_to_df import dict_to_df
 from .import_df_from_file import import_df_from_file
+from .merge_dataframes import merge_dataframes
 
 __all__ = [
     "dict_to_df",
     "import_df_from_file",
+    "merge_dataframes",
 ]

--- a/pandas_functions/merge_dataframes.py
+++ b/pandas_functions/merge_dataframes.py
@@ -1,0 +1,26 @@
+import pandas as pd
+
+
+def merge_dataframes(df1: pd.DataFrame, df2: pd.DataFrame, on: str, how: str = "inner") -> pd.DataFrame:
+    """Merge two pandas DataFrames.
+
+    Parameters
+    ----------
+    df1 : pd.DataFrame
+        The first DataFrame to merge.
+    df2 : pd.DataFrame
+        The second DataFrame to merge.
+    on : str
+        Column name to join on.
+    how : str, optional
+        Type of merge to perform, by default "inner".
+
+    Returns
+    -------
+    pd.DataFrame
+        The merged DataFrame.
+    """
+    return pd.merge(df1, df2, on=on, how=how)
+
+
+__all__ = ["merge_dataframes"]

--- a/pytest/unit/pandas_functions/test_merge_dataframes.py
+++ b/pytest/unit/pandas_functions/test_merge_dataframes.py
@@ -1,0 +1,32 @@
+import numpy as np
+import pandas as pd
+from pandas.testing import assert_frame_equal
+
+from pandas_functions.merge_dataframes import merge_dataframes
+
+
+def test_merge_dataframes_inner():
+    """Verify inner merge returns intersection of keys."""
+    df1 = pd.DataFrame({"id": [1, 2], "value1": ["a", "b"]})
+    df2 = pd.DataFrame({"id": [2, 3], "value2": ["x", "y"]})
+    expected = pd.DataFrame({"id": [2], "value1": ["b"], "value2": ["x"]})
+
+    result = merge_dataframes(df1, df2, on="id", how="inner")
+    assert_frame_equal(result, expected)
+
+
+def test_merge_dataframes_outer():
+    """Verify outer merge includes all keys from both DataFrames."""
+    df1 = pd.DataFrame({"id": [1, 2], "value1": ["a", "b"]})
+    df2 = pd.DataFrame({"id": [2, 3], "value2": ["x", "y"]})
+    expected = pd.DataFrame(
+        {
+            "id": [1, 2, 3],
+            "value1": ["a", "b", np.nan],
+            "value2": [np.nan, "x", "y"],
+        }
+    )
+
+    result = merge_dataframes(df1, df2, on="id", how="outer")
+    assert_frame_equal(result, expected)
+


### PR DESCRIPTION
## Summary
- add merge_dataframes utility using `pd.merge`
- export merge_dataframes from pandas_functions package
- test inner and outer merge behavior

## Testing
- `pytest pytest/unit/pandas_functions/test_merge_dataframes.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5f1866f608325ae0e66c25b000eae