### PR TITLE
Add concat_dfs helper and tests

### DIFF
--- a/pandas_functions/__init__.py
+++ b/pandas_functions/__init__.py
@@ -1,7 +1,9 @@
+from .concat_dfs import concat_dfs
 from .dict_to_df import dict_to_df
 from .import_df_from_file import import_df_from_file
 
 __all__ = [
+    "concat_dfs",
     "dict_to_df",
     "import_df_from_file",
 ]

--- a/pandas_functions/concat_dfs.py
+++ b/pandas_functions/concat_dfs.py
@@ -1,0 +1,36 @@
+import pandas as pd
+from typing import Sequence
+
+
+def concat_dfs(
+    dfs: Sequence[pd.DataFrame],
+    axis: int = 0,
+    ignore_index: bool = False,
+) -> pd.DataFrame:
+    """Concatenate a sequence of DataFrames.
+
+    Parameters
+    ----------
+    dfs : Sequence[pd.DataFrame]
+        Sequence of DataFrames to concatenate. Must contain at least one DataFrame.
+    axis : int, optional
+        Axis along which to concatenate. By default 0.
+    ignore_index : bool, optional
+        If ``True``, ignore the index of the DataFrames. By default ``False``.
+
+    Returns
+    -------
+    pd.DataFrame
+        The concatenated DataFrame.
+
+    Raises
+    ------
+    ValueError
+        If ``dfs`` is empty.
+    """
+    if not dfs:
+        raise ValueError("dfs must be a non-empty sequence of DataFrames")
+    return pd.concat(dfs, axis=axis, ignore_index=ignore_index)
+
+
+__all__ = ["concat_dfs"]

--- a/pytest/unit/pandas_functions/test_concat_dfs.py
+++ b/pytest/unit/pandas_functions/test_concat_dfs.py
@@ -1,0 +1,26 @@
+import pandas as pd
+from pandas_functions import concat_dfs
+
+
+def test_concat_dfs_rows() -> None:
+    """Test concatenating DataFrames along rows."""
+    df1 = pd.DataFrame({"A": [1, 2], "B": [3, 4]})
+    df2 = pd.DataFrame({"A": [5, 6], "B": [7, 8]})
+    result = concat_dfs([df1, df2])
+    expected = pd.DataFrame(
+        {"A": [1, 2, 5, 6], "B": [3, 4, 7, 8]}, index=[0, 1, 0, 1]
+    )
+    assert result.shape == (4, 2)
+    assert list(result.columns) == ["A", "B"]
+    pd.testing.assert_frame_equal(result, expected)
+
+
+def test_concat_dfs_columns() -> None:
+    """Test concatenating DataFrames along columns."""
+    df1 = pd.DataFrame({"A": [1, 2]})
+    df2 = pd.DataFrame({"B": [3, 4]})
+    result = concat_dfs([df1, df2], axis=1)
+    expected = pd.DataFrame({"A": [1, 2], "B": [3, 4]})
+    assert result.shape == (2, 2)
+    assert list(result.columns) == ["A", "B"]
+    pd.testing.assert_frame_equal(result, expected)


### PR DESCRIPTION
## Summary
- add `concat_dfs` function for concatenating a sequence of DataFrames
- export `concat_dfs` in `pandas_functions`
- test row and column concatenation

## Testing
- `pytest pytest/unit/pandas_functions/test_concat_dfs.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5f6acacd083259476112aafa4387a