### PR TITLE
Add DataFrame column filtering helper and tests

### DIFF
--- a/pandas_functions/__init__.py
+++ b/pandas_functions/__init__.py
@@ -1,7 +1,9 @@
 from .dict_to_df import dict_to_df
 from .import_df_from_file import import_df_from_file
+from .filter_df_by_column_value import filter_df_by_column_value
 
 __all__ = [
     "dict_to_df",
     "import_df_from_file",
+    "filter_df_by_column_value",
 ]

--- a/pandas_functions/filter_df_by_column_value.py
+++ b/pandas_functions/filter_df_by_column_value.py
@@ -1,0 +1,32 @@
+import pandas as pd
+from typing import Any
+
+
+def filter_df_by_column_value(df: pd.DataFrame, column: str, value: Any) -> pd.DataFrame:
+    """Filter a DataFrame based on a column's value.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        The DataFrame to filter.
+    column : str
+        Name of the column to filter on.
+    value : Any
+        Value to match in the specified column.
+
+    Returns
+    -------
+    pd.DataFrame
+        A DataFrame containing only rows where ``column`` equals ``value``.
+
+    Raises
+    ------
+    KeyError
+        If ``column`` is not present in ``df``.
+    """
+    if column not in df.columns:
+        raise KeyError(column)
+    return df[df[column] == value]
+
+
+__all__ = ["filter_df_by_column_value"]

--- a/pytest/unit/pandas_functions/test_filter_df_by_column_value.py
+++ b/pytest/unit/pandas_functions/test_filter_df_by_column_value.py
@@ -1,0 +1,17 @@
+import pandas as pd
+import pytest
+
+from pandas_functions import filter_df_by_column_value
+
+
+def test_filter_df_by_column_value():
+    df = pd.DataFrame({"A": [1, 2, 1], "B": ["x", "y", "z"]})
+    expected = pd.DataFrame({"A": [1, 1], "B": ["x", "z"]})
+    result = filter_df_by_column_value(df, "A", 1)
+    pd.testing.assert_frame_equal(result.reset_index(drop=True), expected)
+
+
+def test_filter_df_by_column_value_missing_column():
+    df = pd.DataFrame({"A": [1, 2, 3]})
+    with pytest.raises(KeyError):
+        filter_df_by_column_value(df, "B", 1)


### PR DESCRIPTION
## Summary
- implement `filter_df_by_column_value` to filter pandas DataFrames by column value with validation
- expose new utility in pandas_functions package
- test DataFrame filtering and missing column error handling

## Testing
- `pytest pytest/unit/pandas_functions/test_filter_df_by_column_value.py -q`
- `pytest -q` *(fails: interrupted after 955 passed due to time)*

------
https://chatgpt.com/codex/tasks/task_e_68a5f187061c8325b41b5e37867f7422