### PR TITLE
Add common pandas DataFrame utilities with tests

### DIFF
--- a/pandas_functions/__init__.py
+++ b/pandas_functions/__init__.py
@@ -3,6 +3,9 @@ from .import_df_from_file import import_df_from_file
 from .filter_df_by_column_value import filter_df_by_column_value
 from .merge_dataframes import merge_dataframes
 from .df_to_dict import df_to_dict
+from .select_df_columns import select_df_columns
+from .sort_df_by_columns import sort_df_by_columns
+from .fill_na_in_column import fill_na_in_column
 
 __all__ = [
     "dict_to_df",
@@ -10,4 +13,7 @@ __all__ = [
     "filter_df_by_column_value",
     "merge_dataframes",
     "df_to_dict",
+    "select_df_columns",
+    "sort_df_by_columns",
+    "fill_na_in_column",
 ]

--- a/pandas_functions/fill_na_in_column.py
+++ b/pandas_functions/fill_na_in_column.py
@@ -1,0 +1,36 @@
+import pandas as pd
+from typing import Any
+
+
+def fill_na_in_column(df: pd.DataFrame, column: str, value: Any) -> pd.DataFrame:
+    """Fill missing values in a specific column with ``value``.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        DataFrame containing the column to modify.
+    column : str
+        Name of the column in which ``NaN`` values will be filled.
+    value : Any
+        Value to replace ``NaN`` entries with.
+
+    Returns
+    -------
+    pd.DataFrame
+        A new DataFrame where ``NaN`` values in ``column`` are replaced by ``value``.
+
+    Raises
+    ------
+    KeyError
+        If ``column`` does not exist in ``df``.
+    """
+
+    if column not in df.columns:
+        raise KeyError(column)
+    result = df.copy()
+    result[column] = result[column].fillna(value)
+    return result
+
+
+__all__ = ["fill_na_in_column"]
+

--- a/pandas_functions/select_df_columns.py
+++ b/pandas_functions/select_df_columns.py
@@ -1,0 +1,34 @@
+import pandas as pd
+from collections.abc import Iterable
+
+
+def select_df_columns(df: pd.DataFrame, columns: Iterable[str]) -> pd.DataFrame:
+    """Return a DataFrame with only the specified columns.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        DataFrame to select columns from.
+    columns : Iterable[str]
+        Column names to include in the returned DataFrame.
+
+    Returns
+    -------
+    pd.DataFrame
+        A DataFrame containing only ``columns`` in the order provided.
+
+    Raises
+    ------
+    KeyError
+        If any of ``columns`` are not present in ``df``.
+    """
+
+    columns_list = list(columns)
+    missing = set(columns_list) - set(df.columns)
+    if missing:
+        raise KeyError(f"Columns not found: {missing}")
+    return df[columns_list]
+
+
+__all__ = ["select_df_columns"]
+

--- a/pandas_functions/sort_df_by_columns.py
+++ b/pandas_functions/sort_df_by_columns.py
@@ -1,0 +1,39 @@
+import pandas as pd
+from collections.abc import Sequence
+from typing import Union
+
+
+def sort_df_by_columns(
+    df: pd.DataFrame, columns: Union[str, Sequence[str]], ascending: Union[bool, Sequence[bool]] = True
+) -> pd.DataFrame:
+    """Sort a DataFrame by one or more columns.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        DataFrame to sort.
+    columns : Union[str, Sequence[str]]
+        Column name or names to sort by.
+    ascending : Union[bool, Sequence[bool]], optional
+        Sort ascending or descending for each column, by default ``True``.
+
+    Returns
+    -------
+    pd.DataFrame
+        The sorted DataFrame.
+
+    Raises
+    ------
+    KeyError
+        If any of ``columns`` are not present in ``df``.
+    """
+
+    cols = [columns] if isinstance(columns, str) else list(columns)
+    missing = set(cols) - set(df.columns)
+    if missing:
+        raise KeyError(f"Columns not found: {missing}")
+    return df.sort_values(by=columns, ascending=ascending)
+
+
+__all__ = ["sort_df_by_columns"]
+

--- a/pytest/unit/pandas_functions/test_fill_na_in_column.py
+++ b/pytest/unit/pandas_functions/test_fill_na_in_column.py
@@ -1,0 +1,21 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from pandas_functions.fill_na_in_column import fill_na_in_column
+
+
+def test_fill_na_in_column() -> None:
+    """NaN values in the specified column should be replaced."""
+    df = pd.DataFrame({"A": [1, np.nan, 3]})
+    expected = pd.DataFrame({"A": [1.0, 0.0, 3.0]})
+    result = fill_na_in_column(df, "A", 0)
+    pd.testing.assert_frame_equal(result, expected)
+
+
+def test_fill_na_in_column_missing_column() -> None:
+    """Passing an invalid column name should raise ``KeyError``."""
+    df = pd.DataFrame({"A": [1, 2]})
+    with pytest.raises(KeyError):
+        fill_na_in_column(df, "B", 0)
+

--- a/pytest/unit/pandas_functions/test_select_df_columns.py
+++ b/pytest/unit/pandas_functions/test_select_df_columns.py
@@ -1,0 +1,20 @@
+import pandas as pd
+import pytest
+
+from pandas_functions.select_df_columns import select_df_columns
+
+
+def test_select_df_columns() -> None:
+    """Selecting specific columns should return them in order."""
+    df = pd.DataFrame({"A": [1, 2], "B": [3, 4], "C": [5, 6]})
+    expected = pd.DataFrame({"B": [3, 4], "A": [1, 2]})
+    result = select_df_columns(df, ["B", "A"])
+    pd.testing.assert_frame_equal(result, expected)
+
+
+def test_select_df_columns_missing() -> None:
+    """Requesting a non-existent column should raise ``KeyError``."""
+    df = pd.DataFrame({"A": [1, 2]})
+    with pytest.raises(KeyError):
+        select_df_columns(df, ["B"])
+

--- a/pytest/unit/pandas_functions/test_sort_df_by_columns.py
+++ b/pytest/unit/pandas_functions/test_sort_df_by_columns.py
@@ -1,0 +1,29 @@
+import pandas as pd
+import pytest
+from pandas.testing import assert_frame_equal
+
+from pandas_functions.sort_df_by_columns import sort_df_by_columns
+
+
+def test_sort_df_by_single_column() -> None:
+    """Sorting by a single column should order values ascending."""
+    df = pd.DataFrame({"A": [3, 1, 2]})
+    expected = pd.DataFrame({"A": [1, 2, 3]})
+    result = sort_df_by_columns(df, "A")
+    assert_frame_equal(result.reset_index(drop=True), expected)
+
+
+def test_sort_df_by_multiple_columns_descending() -> None:
+    """Sorting by multiple columns with mixed order should work."""
+    df = pd.DataFrame({"A": [1, 2, 1], "B": [2, 1, 1]})
+    expected = pd.DataFrame({"A": [1, 1, 2], "B": [2, 1, 1]})
+    result = sort_df_by_columns(df, ["A", "B"], ascending=[True, False])
+    assert_frame_equal(result.reset_index(drop=True), expected)
+
+
+def test_sort_df_by_columns_missing() -> None:
+    """Sorting by a non-existent column should raise ``KeyError``."""
+    df = pd.DataFrame({"A": [1, 2]})
+    with pytest.raises(KeyError):
+        sort_df_by_columns(df, "B")
+


### PR DESCRIPTION
## Summary
- add `select_df_columns` for column subsetting with validation
- add `sort_df_by_columns` for configurable multi-column sorting
- add `fill_na_in_column` to replace missing values in a column
- cover new helpers with unit tests

## Testing
- `pytest pytest/unit/pandas_functions`


------
https://chatgpt.com/codex/tasks/task_e_68a6011618e483259140e6f81d2676bf