### PR TITLE
Add additional pandas utilities and tests

### DIFF
--- a/pandas_functions/__init__.py
+++ b/pandas_functions/__init__.py
@@ -8,6 +8,9 @@ from .sort_df_by_columns import sort_df_by_columns
 from .fill_na_in_column import fill_na_in_column
 from .drop_df_columns import drop_df_columns
 from .rename_df_columns import rename_df_columns
+from .concat_dataframes import concat_dataframes
+from .apply_function_to_column import apply_function_to_column
+from .drop_na_df_rows import drop_na_df_rows
 
 __all__ = [
     "dict_to_df",
@@ -20,4 +23,7 @@ __all__ = [
     "fill_na_in_column",
     "drop_df_columns",
     "rename_df_columns",
+    "concat_dataframes",
+    "apply_function_to_column",
+    "drop_na_df_rows",
 ]

--- a/pandas_functions/apply_function_to_column.py
+++ b/pandas_functions/apply_function_to_column.py
@@ -1,0 +1,35 @@
+import pandas as pd
+from collections.abc import Callable
+from typing import Any
+
+
+def apply_function_to_column(df: pd.DataFrame, column: str, func: Callable[[Any], Any]) -> pd.DataFrame:
+    """Apply ``func`` to ``column`` of ``df``.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        DataFrame whose column will be modified.
+    column : str
+        Name of the column to apply ``func`` to.
+    func : Callable[[Any], Any]
+        Function to apply to each element of the column.
+
+    Returns
+    -------
+    pd.DataFrame
+        DataFrame with the modified column.
+
+    Raises
+    ------
+    KeyError
+        If ``column`` is not present in ``df``.
+    """
+    if column not in df.columns:
+        raise KeyError(column)
+    result = df.copy()
+    result[column] = result[column].apply(func)
+    return result
+
+
+__all__ = ["apply_function_to_column"]

--- a/pandas_functions/concat_dataframes.py
+++ b/pandas_functions/concat_dataframes.py
@@ -1,0 +1,37 @@
+import pandas as pd
+from collections.abc import Iterable
+
+
+def concat_dataframes(dfs: Iterable[pd.DataFrame], axis: int = 0, ignore_index: bool = True) -> pd.DataFrame:
+    """Concatenate an iterable of pandas DataFrames.
+
+    Parameters
+    ----------
+    dfs : Iterable[pd.DataFrame]
+        Sequence of DataFrames to concatenate.
+    axis : int, optional
+        Axis to concatenate along, by default ``0``.
+    ignore_index : bool, optional
+        Whether to ignore the index in the result, by default ``True``.
+
+    Returns
+    -------
+    pd.DataFrame
+        The concatenated DataFrame.
+
+    Raises
+    ------
+    TypeError
+        If any element in ``dfs`` is not a pandas DataFrame.
+    ValueError
+        If ``dfs`` is empty.
+    """
+    dfs_list = list(dfs)
+    if not dfs_list:
+        raise ValueError("dfs must contain at least one DataFrame")
+    if not all(isinstance(df, pd.DataFrame) for df in dfs_list):
+        raise TypeError("All items in dfs must be pandas DataFrames")
+    return pd.concat(dfs_list, axis=axis, ignore_index=ignore_index)
+
+
+__all__ = ["concat_dataframes"]

--- a/pandas_functions/drop_na_df_rows.py
+++ b/pandas_functions/drop_na_df_rows.py
@@ -1,0 +1,35 @@
+import pandas as pd
+from collections.abc import Iterable
+
+
+def drop_na_df_rows(df: pd.DataFrame, columns: Iterable[str] | None = None) -> pd.DataFrame:
+    """Drop rows with missing values from ``df``.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        DataFrame to drop rows from.
+    columns : Iterable[str] | None, optional
+        Columns to consider when identifying NA values. If ``None``, all columns are used.
+
+    Returns
+    -------
+    pd.DataFrame
+        DataFrame with rows containing NA values removed.
+
+    Raises
+    ------
+    KeyError
+        If any of ``columns`` are not present in ``df``.
+    """
+    if columns is not None:
+        columns_list = list(columns)
+        missing = set(columns_list) - set(df.columns)
+        if missing:
+            raise KeyError(f"Columns not found: {missing}")
+    else:
+        columns_list = None
+    return df.dropna(subset=columns_list)
+
+
+__all__ = ["drop_na_df_rows"]

--- a/pytest/unit/pandas_functions/test_apply_function_to_column.py
+++ b/pytest/unit/pandas_functions/test_apply_function_to_column.py
@@ -1,0 +1,17 @@
+import pandas as pd
+import pytest
+
+from pandas_functions import apply_function_to_column
+
+
+def test_apply_function_to_column():
+    df = pd.DataFrame({"A": [1, 2, 3]})
+    result = apply_function_to_column(df, "A", lambda x: x * 2)
+    expected = pd.DataFrame({"A": [2, 4, 6]})
+    pd.testing.assert_frame_equal(result, expected)
+
+
+def test_apply_function_to_column_missing():
+    df = pd.DataFrame({"A": [1]})
+    with pytest.raises(KeyError):
+        apply_function_to_column(df, "B", lambda x: x)

--- a/pytest/unit/pandas_functions/test_concat_dataframes.py
+++ b/pytest/unit/pandas_functions/test_concat_dataframes.py
@@ -1,0 +1,23 @@
+import pandas as pd
+import pytest
+
+from pandas_functions import concat_dataframes
+
+
+def test_concat_dataframes():
+    df1 = pd.DataFrame({"A": [1, 2]})
+    df2 = pd.DataFrame({"A": [3]})
+    result = concat_dataframes([df1, df2])
+    expected = pd.DataFrame({"A": [1, 2, 3]})
+    pd.testing.assert_frame_equal(result.reset_index(drop=True), expected)
+
+
+def test_concat_dataframes_type_error():
+    df1 = pd.DataFrame({"A": [1]})
+    with pytest.raises(TypeError):
+        concat_dataframes([df1, "not a df"])
+
+
+def test_concat_dataframes_empty():
+    with pytest.raises(ValueError):
+        concat_dataframes([])

--- a/pytest/unit/pandas_functions/test_drop_na_df_rows.py
+++ b/pytest/unit/pandas_functions/test_drop_na_df_rows.py
@@ -1,0 +1,24 @@
+import pandas as pd
+import pytest
+
+from pandas_functions import drop_na_df_rows
+
+
+def test_drop_na_df_rows_subset():
+    df = pd.DataFrame({"A": [1, None, 2], "B": [4, 5, None]})
+    result = drop_na_df_rows(df, ["A"])
+    expected = pd.DataFrame({"A": [1, 2], "B": [4, None]})
+    pd.testing.assert_frame_equal(result.reset_index(drop=True), expected)
+
+
+def test_drop_na_df_rows_all_columns():
+    df = pd.DataFrame({"A": [1, None], "B": [4, 5]})
+    result = drop_na_df_rows(df)
+    expected = pd.DataFrame({"A": [1], "B": [4]})
+    pd.testing.assert_frame_equal(result.reset_index(drop=True), expected)
+
+
+def test_drop_na_df_rows_missing_column():
+    df = pd.DataFrame({"A": [1, None]})
+    with pytest.raises(KeyError):
+        drop_na_df_rows(df, ["B"])


### PR DESCRIPTION
## Summary
- add helper to concatenate multiple dataframes
- allow applying custom function to a dataframe column
- support dropping rows with missing values and import utilities in package init

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a607029bac8325b426705d893334ce