### PR TITLE
Add DataFrame column prefixing and dtype conversion utilities

### DIFF
--- a/pandas_functions/__init__.py
+++ b/pandas_functions/__init__.py
@@ -11,6 +11,8 @@ from .rename_df_columns import rename_df_columns
 from .concat_dataframes import concat_dataframes
 from .apply_function_to_column import apply_function_to_column
 from .drop_na_df_rows import drop_na_df_rows
+from .add_prefix_to_df_columns import add_prefix_to_df_columns
+from .convert_df_column_dtype import convert_df_column_dtype
 
 __all__ = [
     "dict_to_df",
@@ -26,4 +28,6 @@ __all__ = [
     "concat_dataframes",
     "apply_function_to_column",
     "drop_na_df_rows",
+    "add_prefix_to_df_columns",
+    "convert_df_column_dtype",
 ]

--- a/pandas_functions/add_prefix_to_df_columns.py
+++ b/pandas_functions/add_prefix_to_df_columns.py
@@ -1,0 +1,22 @@
+import pandas as pd
+
+
+def add_prefix_to_df_columns(df: pd.DataFrame, prefix: str) -> pd.DataFrame:
+    """Add ``prefix`` to each column name of ``df``.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        DataFrame whose column names will be modified.
+    prefix : str
+        Prefix to prepend to each column name.
+
+    Returns
+    -------
+    pd.DataFrame
+        DataFrame with updated column names.
+    """
+    return df.add_prefix(prefix)
+
+
+__all__ = ["add_prefix_to_df_columns"]

--- a/pandas_functions/convert_df_column_dtype.py
+++ b/pandas_functions/convert_df_column_dtype.py
@@ -1,0 +1,33 @@
+import pandas as pd
+
+
+def convert_df_column_dtype(df: pd.DataFrame, column: str, dtype: str | type) -> pd.DataFrame:
+    """Convert ``column`` of ``df`` to ``dtype``.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        DataFrame containing the column to convert.
+    column : str
+        Name of the column to convert.
+    dtype : str | type
+        Target data type for the column.
+
+    Returns
+    -------
+    pd.DataFrame
+        DataFrame with the converted column.
+
+    Raises
+    ------
+    KeyError
+        If ``column`` is not present in ``df``.
+    """
+    if column not in df.columns:
+        raise KeyError(column)
+    result = df.copy()
+    result[column] = result[column].astype(dtype)
+    return result
+
+
+__all__ = ["convert_df_column_dtype"]

--- a/pytest/unit/pandas_functions/test_add_prefix_to_df_columns.py
+++ b/pytest/unit/pandas_functions/test_add_prefix_to_df_columns.py
@@ -1,0 +1,11 @@
+import pandas as pd
+
+from pandas_functions.add_prefix_to_df_columns import add_prefix_to_df_columns
+
+
+def test_add_prefix_to_df_columns() -> None:
+    """Adding a prefix should rename all columns."""
+    df = pd.DataFrame({"A": [1], "B": [2]})
+    expected = pd.DataFrame({"pre_A": [1], "pre_B": [2]})
+    result = add_prefix_to_df_columns(df, "pre_")
+    pd.testing.assert_frame_equal(result, expected)

--- a/pytest/unit/pandas_functions/test_convert_df_column_dtype.py
+++ b/pytest/unit/pandas_functions/test_convert_df_column_dtype.py
@@ -1,0 +1,19 @@
+import pandas as pd
+import pytest
+
+from pandas_functions.convert_df_column_dtype import convert_df_column_dtype
+
+
+def test_convert_df_column_dtype() -> None:
+    """Converting a column should change its dtype."""
+    df = pd.DataFrame({"A": ["1", "2"]})
+    result = convert_df_column_dtype(df, "A", int)
+    expected = pd.DataFrame({"A": [1, 2]})
+    pd.testing.assert_frame_equal(result, expected)
+
+
+def test_convert_df_column_dtype_missing() -> None:
+    """Requesting a missing column should raise ``KeyError``."""
+    df = pd.DataFrame({"A": [1]})
+    with pytest.raises(KeyError):
+        convert_df_column_dtype(df, "B", int)


### PR DESCRIPTION
## Summary
- add helper to prepend prefixes to DataFrame column names
- add utility to convert a DataFrame column to a specified dtype
- cover new helpers with unit tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a6191a0d6c83259c01a5051f4cebfc