### PR TITLE
Add DataFrame duplicate removal and value replacement utilities

### DIFF
--- a/pandas_functions/__init__.py
+++ b/pandas_functions/__init__.py
@@ -13,6 +13,8 @@ from .apply_function_to_column import apply_function_to_column
 from .drop_na_df_rows import drop_na_df_rows
 from .add_prefix_to_df_columns import add_prefix_to_df_columns
 from .convert_df_column_dtype import convert_df_column_dtype
+from .drop_duplicate_df_rows import drop_duplicate_df_rows
+from .replace_df_column_values import replace_df_column_values
 
 __all__ = [
     "dict_to_df",
@@ -30,4 +32,6 @@ __all__ = [
     "drop_na_df_rows",
     "add_prefix_to_df_columns",
     "convert_df_column_dtype",
+    "drop_duplicate_df_rows",
+    "replace_df_column_values",
 ]

--- a/pandas_functions/drop_duplicate_df_rows.py
+++ b/pandas_functions/drop_duplicate_df_rows.py
@@ -1,0 +1,39 @@
+import pandas as pd
+from collections.abc import Iterable
+from typing import Literal
+
+
+def drop_duplicate_df_rows(
+    df: pd.DataFrame,
+    subset: Iterable[str] | None = None,
+    keep: Literal["first", "last", False] = "first",
+) -> pd.DataFrame:
+    """Return ``df`` with duplicate rows removed.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        DataFrame to remove duplicates from.
+    subset : Iterable[str] | None, optional
+        Columns to consider when identifying duplicates. If ``None``,
+        all columns are used.
+    keep : {"first", "last", False}, optional
+        Which duplicate to keep. Default is ``"first"``.
+
+    Returns
+    -------
+    pd.DataFrame
+        DataFrame with duplicate rows removed.
+
+    Raises
+    ------
+    ValueError
+        If ``keep`` is not one of ``"first"``, ``"last"`` or ``False``.
+    """
+    if keep not in {"first", "last", False}:
+        raise ValueError("keep must be 'first', 'last' or False")
+    subset_list = list(subset) if subset is not None else None
+    return df.drop_duplicates(subset=subset_list, keep=keep)
+
+
+__all__ = ["drop_duplicate_df_rows"]

--- a/pandas_functions/replace_df_column_values.py
+++ b/pandas_functions/replace_df_column_values.py
@@ -1,0 +1,35 @@
+import pandas as pd
+
+
+def replace_df_column_values(
+    df: pd.DataFrame, column: str, value_map: dict[object, object]
+) -> pd.DataFrame:
+    """Replace values in ``column`` of ``df`` using ``value_map``.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        DataFrame containing the column to modify.
+    column : str
+        Name of the column whose values will be replaced.
+    value_map : dict[object, object]
+        Mapping from existing values to new values.
+
+    Returns
+    -------
+    pd.DataFrame
+        DataFrame with updated column values.
+
+    Raises
+    ------
+    KeyError
+        If ``column`` is not present in ``df``.
+    """
+    if column not in df.columns:
+        raise KeyError(column)
+    result = df.copy()
+    result[column] = result[column].replace(value_map)
+    return result
+
+
+__all__ = ["replace_df_column_values"]

--- a/pytest/unit/pandas_functions/test_drop_duplicate_df_rows.py
+++ b/pytest/unit/pandas_functions/test_drop_duplicate_df_rows.py
@@ -1,0 +1,19 @@
+import pandas as pd
+import pytest
+
+from pandas_functions.drop_duplicate_df_rows import drop_duplicate_df_rows
+
+
+def test_drop_duplicate_df_rows() -> None:
+    """Duplicate rows should be removed."""
+    df = pd.DataFrame({"A": [1, 1, 2], "B": [3, 3, 4]})
+    expected = pd.DataFrame({"A": [1, 2], "B": [3, 4]})
+    result = drop_duplicate_df_rows(df)
+    pd.testing.assert_frame_equal(result.reset_index(drop=True), expected)
+
+
+def test_drop_duplicate_df_rows_invalid_keep() -> None:
+    """Invalid ``keep`` value should raise ``ValueError``."""
+    df = pd.DataFrame({"A": [1, 1]})
+    with pytest.raises(ValueError):
+        drop_duplicate_df_rows(df, keep="invalid")

--- a/pytest/unit/pandas_functions/test_replace_df_column_values.py
+++ b/pytest/unit/pandas_functions/test_replace_df_column_values.py
@@ -1,0 +1,19 @@
+import pandas as pd
+import pytest
+
+from pandas_functions.replace_df_column_values import replace_df_column_values
+
+
+def test_replace_df_column_values() -> None:
+    """Values in a column should be replaced using the mapping."""
+    df = pd.DataFrame({"A": [1, 2, 1]})
+    expected = pd.DataFrame({"A": ["one", "two", "one"]})
+    result = replace_df_column_values(df, "A", {1: "one", 2: "two"})
+    pd.testing.assert_frame_equal(result, expected)
+
+
+def test_replace_df_column_values_missing_column() -> None:
+    """Replacing a non-existent column should raise ``KeyError``."""
+    df = pd.DataFrame({"A": [1]})
+    with pytest.raises(KeyError):
+        replace_df_column_values(df, "B", {1: "one"})


### PR DESCRIPTION
## Summary
- add `drop_duplicate_df_rows` to remove duplicate records from a DataFrame
- add `replace_df_column_values` to map values in a DataFrame column
- cover new helpers with comprehensive unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a61a6c17d88325af0632227743b465