### PR TITLE
Add DataFrame suffix and multi-value filter helpers

### DIFF
--- a/pandas_functions/__init__.py
+++ b/pandas_functions/__init__.py
@@ -12,9 +12,11 @@ from .concat_dataframes import concat_dataframes
 from .apply_function_to_column import apply_function_to_column
 from .drop_na_df_rows import drop_na_df_rows
 from .add_prefix_to_df_columns import add_prefix_to_df_columns
+from .add_suffix_to_df_columns import add_suffix_to_df_columns
 from .convert_df_column_dtype import convert_df_column_dtype
 from .drop_duplicate_df_rows import drop_duplicate_df_rows
 from .replace_df_column_values import replace_df_column_values
+from .filter_df_by_column_values import filter_df_by_column_values
 
 __all__ = [
     "dict_to_df",
@@ -31,7 +33,9 @@ __all__ = [
     "apply_function_to_column",
     "drop_na_df_rows",
     "add_prefix_to_df_columns",
+    "add_suffix_to_df_columns",
     "convert_df_column_dtype",
     "drop_duplicate_df_rows",
     "replace_df_column_values",
+    "filter_df_by_column_values",
 ]

--- a/pandas_functions/add_suffix_to_df_columns.py
+++ b/pandas_functions/add_suffix_to_df_columns.py
@@ -1,0 +1,22 @@
+import pandas as pd
+
+
+def add_suffix_to_df_columns(df: pd.DataFrame, suffix: str) -> pd.DataFrame:
+    """Add ``suffix`` to each column name of ``df``.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        DataFrame whose column names will be modified.
+    suffix : str
+        Suffix to append to each column name.
+
+    Returns
+    -------
+    pd.DataFrame
+        DataFrame with updated column names.
+    """
+    return df.add_suffix(suffix)
+
+
+__all__ = ["add_suffix_to_df_columns"]

--- a/pandas_functions/filter_df_by_column_values.py
+++ b/pandas_functions/filter_df_by_column_values.py
@@ -1,0 +1,35 @@
+import pandas as pd
+from collections.abc import Iterable
+from typing import Any
+
+
+def filter_df_by_column_values(
+    df: pd.DataFrame, column: str, values: Iterable[Any]
+) -> pd.DataFrame:
+    """Filter a DataFrame based on multiple values in a column.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        The DataFrame to filter.
+    column : str
+        Name of the column to filter on.
+    values : Iterable[Any]
+        Collection of values to match in the specified column.
+
+    Returns
+    -------
+    pd.DataFrame
+        A DataFrame containing only rows where ``column`` equals any value in ``values``.
+
+    Raises
+    ------
+    KeyError
+        If ``column`` is not present in ``df``.
+    """
+    if column not in df.columns:
+        raise KeyError(column)
+    return df[df[column].isin(values)]
+
+
+__all__ = ["filter_df_by_column_values"]

--- a/pytest/unit/pandas_functions/test_add_suffix_to_df_columns.py
+++ b/pytest/unit/pandas_functions/test_add_suffix_to_df_columns.py
@@ -1,0 +1,11 @@
+import pandas as pd
+
+from pandas_functions.add_suffix_to_df_columns import add_suffix_to_df_columns
+
+
+def test_add_suffix_to_df_columns() -> None:
+    """Adding a suffix should rename all columns."""
+    df = pd.DataFrame({"A": [1], "B": [2]})
+    expected = pd.DataFrame({"A_suf": [1], "B_suf": [2]})
+    result = add_suffix_to_df_columns(df, "_suf")
+    pd.testing.assert_frame_equal(result, expected)

--- a/pytest/unit/pandas_functions/test_filter_df_by_column_values.py
+++ b/pytest/unit/pandas_functions/test_filter_df_by_column_values.py
@@ -1,0 +1,19 @@
+import pandas as pd
+import pytest
+
+from pandas_functions.filter_df_by_column_values import filter_df_by_column_values
+
+
+def test_filter_df_by_column_values() -> None:
+    """Filtering by multiple values should return matching rows."""
+    df = pd.DataFrame({"A": [1, 2, 3], "B": ["x", "y", "z"]})
+    expected = pd.DataFrame({"A": [1, 3], "B": ["x", "z"]}, index=[0, 2])
+    result = filter_df_by_column_values(df, "A", [1, 3])
+    pd.testing.assert_frame_equal(result, expected)
+
+
+def test_filter_df_by_column_values_missing() -> None:
+    """Filtering on a non-existent column should raise ``KeyError``."""
+    df = pd.DataFrame({"A": [1]})
+    with pytest.raises(KeyError):
+        filter_df_by_column_values(df, "B", [1])


### PR DESCRIPTION
## Summary
- add `add_suffix_to_df_columns` to append text to column names
- add `filter_df_by_column_values` for multi-value row filtering
- cover new helpers with unit tests and export them from module

## Testing
- `pytest pytest/unit/pandas_functions/test_add_suffix_to_df_columns.py pytest/unit/pandas_functions/test_filter_df_by_column_values.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a6313b83488325819f6234264609df