### PR TITLE
Add additional pandas utilities and tests

### DIFF
--- a/pandas_functions/__init__.py
+++ b/pandas_functions/__init__.py
@@ -17,6 +17,9 @@ from .convert_df_column_dtype import convert_df_column_dtype
 from .drop_duplicate_df_rows import drop_duplicate_df_rows
 from .replace_df_column_values import replace_df_column_values
 from .filter_df_by_column_values import filter_df_by_column_values
+from .drop_na_df_columns import drop_na_df_columns
+from .reset_df_index import reset_df_index
+from .set_df_index import set_df_index
 
 __all__ = [
     "dict_to_df",
@@ -38,4 +41,7 @@ __all__ = [
     "drop_duplicate_df_rows",
     "replace_df_column_values",
     "filter_df_by_column_values",
+    "drop_na_df_columns",
+    "reset_df_index",
+    "set_df_index",
 ]

--- a/pandas_functions/drop_na_df_columns.py
+++ b/pandas_functions/drop_na_df_columns.py
@@ -1,0 +1,23 @@
+import pandas as pd
+
+
+def drop_na_df_columns(df: pd.DataFrame, how: str = "any") -> pd.DataFrame:
+    """Remove columns from ``df`` that contain NA values.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        DataFrame to drop columns from.
+    how : {"any", "all"}, default "any"
+        Determine whether to drop a column if it contains any NA values
+        or only if all values are NA.
+
+    Returns
+    -------
+    pd.DataFrame
+        DataFrame without columns containing NA values.
+    """
+    return df.dropna(axis=1, how=how)
+
+
+__all__ = ["drop_na_df_columns"]

--- a/pandas_functions/reset_df_index.py
+++ b/pandas_functions/reset_df_index.py
@@ -1,0 +1,22 @@
+import pandas as pd
+
+
+def reset_df_index(df: pd.DataFrame, drop: bool = False) -> pd.DataFrame:
+    """Return ``df`` with its index reset.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        DataFrame whose index will be reset.
+    drop : bool, default False
+        If True, do not insert the index into the DataFrame columns.
+
+    Returns
+    -------
+    pd.DataFrame
+        DataFrame with a new sequential index.
+    """
+    return df.reset_index(drop=drop)
+
+
+__all__ = ["reset_df_index"]

--- a/pandas_functions/set_df_index.py
+++ b/pandas_functions/set_df_index.py
@@ -1,0 +1,36 @@
+import pandas as pd
+from collections.abc import Iterable
+
+
+def set_df_index(
+    df: pd.DataFrame, columns: Iterable[str], drop: bool = True
+) -> pd.DataFrame:
+    """Return ``df`` with ``columns`` set as the index.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        DataFrame to modify.
+    columns : Iterable[str]
+        Column names to set as the new index.
+    drop : bool, default True
+        Whether to delete ``columns`` from ``df``.
+
+    Returns
+    -------
+    pd.DataFrame
+        DataFrame with ``columns`` as index.
+
+    Raises
+    ------
+    KeyError
+        If any of ``columns`` do not exist in ``df``.
+    """
+    columns_list = list(columns)
+    missing = set(columns_list) - set(df.columns)
+    if missing:
+        raise KeyError(f"Columns not found: {missing}")
+    return df.set_index(columns_list, drop=drop)
+
+
+__all__ = ["set_df_index"]

--- a/pytest/unit/pandas_functions/test_drop_na_df_columns.py
+++ b/pytest/unit/pandas_functions/test_drop_na_df_columns.py
@@ -1,0 +1,19 @@
+import pandas as pd
+
+from pandas_functions.drop_na_df_columns import drop_na_df_columns
+
+
+def test_drop_na_df_columns_any() -> None:
+    """Columns with any NA values should be dropped by default."""
+    df = pd.DataFrame({"A": [1, 2], "B": [None, None], "C": [1, None]})
+    result = drop_na_df_columns(df)
+    expected = pd.DataFrame({"A": [1, 2]})
+    pd.testing.assert_frame_equal(result, expected)
+
+
+def test_drop_na_df_columns_all() -> None:
+    """Using ``how='all'`` should only drop columns with all NA values."""
+    df = pd.DataFrame({"A": [1, 2], "B": [None, None], "C": [1, None]})
+    result = drop_na_df_columns(df, how="all")
+    expected = pd.DataFrame({"A": [1, 2], "C": [1, None]})
+    pd.testing.assert_frame_equal(result, expected)

--- a/pytest/unit/pandas_functions/test_reset_df_index.py
+++ b/pytest/unit/pandas_functions/test_reset_df_index.py
@@ -1,0 +1,19 @@
+import pandas as pd
+
+from pandas_functions.reset_df_index import reset_df_index
+
+
+def test_reset_df_index() -> None:
+    """Resetting the index should move it to a column by default."""
+    df = pd.DataFrame({"A": [1, 2]}, index=["x", "y"])
+    result = reset_df_index(df)
+    expected = pd.DataFrame({"index": ["x", "y"], "A": [1, 2]})
+    pd.testing.assert_frame_equal(result, expected)
+
+
+def test_reset_df_index_drop() -> None:
+    """Dropping the index should remove it from the DataFrame."""
+    df = pd.DataFrame({"A": [1, 2]}, index=[10, 11])
+    result = reset_df_index(df, drop=True)
+    expected = pd.DataFrame({"A": [1, 2]})
+    pd.testing.assert_frame_equal(result, expected)

--- a/pytest/unit/pandas_functions/test_set_df_index.py
+++ b/pytest/unit/pandas_functions/test_set_df_index.py
@@ -1,0 +1,27 @@
+import pandas as pd
+import pytest
+
+from pandas_functions.set_df_index import set_df_index
+
+
+def test_set_df_index() -> None:
+    """Setting a column as index should remove it by default."""
+    df = pd.DataFrame({"A": [1, 2], "B": ["x", "y"]})
+    result = set_df_index(df, ["B"])
+    expected = pd.DataFrame({"A": [1, 2]}, index=pd.Index(["x", "y"], name="B"))
+    pd.testing.assert_frame_equal(result, expected)
+
+
+def test_set_df_index_drop_false() -> None:
+    """Setting the index with ``drop=False`` should retain the column."""
+    df = pd.DataFrame({"A": [1, 2], "B": ["x", "y"]})
+    result = set_df_index(df, ["B"], drop=False)
+    expected = pd.DataFrame({"A": [1, 2], "B": ["x", "y"]}).set_index("B", drop=False)
+    pd.testing.assert_frame_equal(result, expected)
+
+
+def test_set_df_index_missing() -> None:
+    """Setting a non-existent column as index should raise ``KeyError``."""
+    df = pd.DataFrame({"A": [1, 2]})
+    with pytest.raises(KeyError):
+        set_df_index(df, ["B"])


### PR DESCRIPTION
## Summary
- add helper to drop DataFrame columns containing nulls
- new index helpers to reset and set DataFrame index
- cover new utilities with unit tests and export in module

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a632ef1b20832590696f38d81eaa54