### PR TITLE
Add DataFrame reshaping helpers

### DIFF
--- a/pandas_functions/__init__.py
+++ b/pandas_functions/__init__.py
@@ -20,6 +20,9 @@ from .filter_df_by_column_values import filter_df_by_column_values
 from .drop_na_df_columns import drop_na_df_columns
 from .reset_df_index import reset_df_index
 from .set_df_index import set_df_index
+from .group_df_by_columns import group_df_by_columns
+from .pivot_df import pivot_df
+from .melt_df import melt_df
 
 __all__ = [
     "dict_to_df",
@@ -44,4 +47,7 @@ __all__ = [
     "drop_na_df_columns",
     "reset_df_index",
     "set_df_index",
+    "group_df_by_columns",
+    "pivot_df",
+    "melt_df",
 ]

--- a/pandas_functions/group_df_by_columns.py
+++ b/pandas_functions/group_df_by_columns.py
@@ -1,0 +1,29 @@
+import pandas as pd
+from collections.abc import Iterable, Mapping, Callable
+
+
+def group_df_by_columns(
+    df: pd.DataFrame,
+    group_cols: str | Iterable[str],
+    agg: Mapping[str, Callable | str | Iterable[Callable | str]],
+) -> pd.DataFrame:
+    """Group a DataFrame by the specified columns and aggregate.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        DataFrame to group.
+    group_cols : str or Iterable[str]
+        Column name(s) to group by.
+    agg : Mapping[str, Callable | str | Iterable[Callable | str]]
+        Aggregation instructions passed to ``DataFrame.groupby().agg``.
+
+    Returns
+    -------
+    pd.DataFrame
+        Aggregated DataFrame with the group columns as regular columns.
+    """
+    return df.groupby(group_cols).agg(agg).reset_index()
+
+
+__all__ = ["group_df_by_columns"]

--- a/pandas_functions/melt_df.py
+++ b/pandas_functions/melt_df.py
@@ -1,0 +1,45 @@
+import pandas as pd
+from collections.abc import Iterable
+
+
+def melt_df(
+    df: pd.DataFrame,
+    id_vars: str | Iterable[str] | None = None,
+    value_vars: str | Iterable[str] | None = None,
+    var_name: str | None = None,
+    value_name: str = "value",
+    ignore_index: bool = True,
+) -> pd.DataFrame:
+    """Unpivot a DataFrame from wide to long format.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        DataFrame to melt.
+    id_vars : str or Iterable[str], optional
+        Column(s) to use as identifier variables.
+    value_vars : str or Iterable[str], optional
+        Column(s) to unpivot. If ``None``, use all columns that are not id_vars.
+    var_name : str, optional
+        Name to use for the variable column.
+    value_name : str, optional
+        Name to use for the value column, by default ``"value"``.
+    ignore_index : bool, optional
+        If ``True``, original index is ignored, by default ``True``.
+
+    Returns
+    -------
+    pd.DataFrame
+        Melted DataFrame.
+    """
+    return pd.melt(
+        df,
+        id_vars=id_vars,
+        value_vars=value_vars,
+        var_name=var_name,
+        value_name=value_name,
+        ignore_index=ignore_index,
+    )
+
+
+__all__ = ["melt_df"]

--- a/pandas_functions/pivot_df.py
+++ b/pandas_functions/pivot_df.py
@@ -1,0 +1,45 @@
+import pandas as pd
+from collections.abc import Iterable, Callable
+
+
+def pivot_df(
+    df: pd.DataFrame,
+    index: str | Iterable[str],
+    columns: str | Iterable[str],
+    values: str,
+    aggfunc: Callable | str = "mean",
+    fill_value: object | None = None,
+) -> pd.DataFrame:
+    """Create a pivot table from a DataFrame.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Input DataFrame.
+    index : str or Iterable[str]
+        Column(s) to use as the new index.
+    columns : str or Iterable[str]
+        Column(s) to use to make new columns.
+    values : str
+        Column to aggregate.
+    aggfunc : Callable or str, optional
+        Aggregation function, by default ``"mean"``.
+    fill_value : object, optional
+        Value to replace missing entries with, by default ``None``.
+
+    Returns
+    -------
+    pd.DataFrame
+        Pivot table DataFrame.
+    """
+    return pd.pivot_table(
+        df,
+        index=index,
+        columns=columns,
+        values=values,
+        aggfunc=aggfunc,
+        fill_value=fill_value,
+    )
+
+
+__all__ = ["pivot_df"]

--- a/pytest/unit/pandas_functions/test_drop_na_df_rows.py
+++ b/pytest/unit/pandas_functions/test_drop_na_df_rows.py
@@ -7,14 +7,14 @@ from pandas_functions import drop_na_df_rows
 def test_drop_na_df_rows_subset():
     df = pd.DataFrame({"A": [1, None, 2], "B": [4, 5, None]})
     result = drop_na_df_rows(df, ["A"])
-    expected = pd.DataFrame({"A": [1, 2], "B": [4, None]})
+    expected = pd.DataFrame({"A": [1.0, 2.0], "B": [4.0, None]})
     pd.testing.assert_frame_equal(result.reset_index(drop=True), expected)
 
 
 def test_drop_na_df_rows_all_columns():
     df = pd.DataFrame({"A": [1, None], "B": [4, 5]})
     result = drop_na_df_rows(df)
-    expected = pd.DataFrame({"A": [1], "B": [4]})
+    expected = pd.DataFrame({"A": [1.0], "B": [4]})
     pd.testing.assert_frame_equal(result.reset_index(drop=True), expected)
 
 

--- a/pytest/unit/pandas_functions/test_group_df_by_columns.py
+++ b/pytest/unit/pandas_functions/test_group_df_by_columns.py
@@ -1,0 +1,17 @@
+import pandas as pd
+import pytest
+
+from pandas_functions import group_df_by_columns
+
+
+def test_group_df_by_columns():
+    df = pd.DataFrame({"A": ["x", "x", "y"], "B": [1, 2, 3], "C": [4, 5, 6]})
+    expected = pd.DataFrame({"A": ["x", "y"], "B": [1.5, 3.0], "C": [9, 6]})
+    result = group_df_by_columns(df, "A", {"B": "mean", "C": "sum"})
+    pd.testing.assert_frame_equal(result, expected)
+
+
+def test_group_df_by_columns_missing_column():
+    df = pd.DataFrame({"A": [1, 2], "B": [3, 4]})
+    with pytest.raises(KeyError):
+        group_df_by_columns(df, "C", {"B": "sum"})

--- a/pytest/unit/pandas_functions/test_melt_df.py
+++ b/pytest/unit/pandas_functions/test_melt_df.py
@@ -1,0 +1,19 @@
+import pandas as pd
+import pytest
+
+from pandas_functions import melt_df
+
+
+def test_melt_df():
+    df = pd.DataFrame({"A": [1, 2], "B": [3, 4], "C": [5, 6]})
+    expected = pd.DataFrame(
+        {"A": [1, 2, 1, 2], "variable": ["B", "B", "C", "C"], "value": [3, 4, 5, 6]}
+    )
+    result = melt_df(df, id_vars="A", value_vars=["B", "C"], var_name="variable", value_name="value")
+    pd.testing.assert_frame_equal(result, expected)
+
+
+def test_melt_df_missing_column():
+    df = pd.DataFrame({"A": [1, 2], "B": [3, 4]})
+    with pytest.raises(KeyError):
+        melt_df(df, id_vars="A", value_vars=["B", "C"])

--- a/pytest/unit/pandas_functions/test_pivot_df.py
+++ b/pytest/unit/pandas_functions/test_pivot_df.py
@@ -1,0 +1,20 @@
+import pandas as pd
+import pytest
+
+from pandas_functions import pivot_df
+
+
+def test_pivot_df():
+    df = pd.DataFrame({"A": [1, 1, 2], "B": ["x", "y", "x"], "C": [10, 20, 30]})
+    expected = pd.DataFrame(
+        {"x": [10, 30], "y": [20, 0]}, index=pd.Index([1, 2], name="A")
+    )
+    expected.columns.name = "B"
+    result = pivot_df(df, index="A", columns="B", values="C", aggfunc="sum", fill_value=0)
+    pd.testing.assert_frame_equal(result, expected)
+
+
+def test_pivot_df_missing_column():
+    df = pd.DataFrame({"A": [1, 2], "B": [3, 4]})
+    with pytest.raises(KeyError):
+        pivot_df(df, index="A", columns="B", values="C")


### PR DESCRIPTION
## Summary
- add `group_df_by_columns` for grouping and aggregating DataFrames
- add `pivot_df` and `melt_df` helpers for common reshaping operations
- expose new helpers via package and cover them with unit tests
- fix drop-na row tests for float column types

## Testing
- `pytest pytest/unit/pandas_functions/test_group_df_by_columns.py pytest/unit/pandas_functions/test_pivot_df.py pytest/unit/pandas_functions/test_melt_df.py -q`
- `pytest pytest/unit/pandas_functions -q`


------
https://chatgpt.com/codex/tasks/task_e_68a64fe205e08325bb8cff646b295685