### PR TITLE
Add DataFrame index sorting and row shuffling utilities

### DIFF
--- a/pandas_functions/__init__.py
+++ b/pandas_functions/__init__.py
@@ -23,6 +23,8 @@ from .set_df_index import set_df_index
 from .group_df_by_columns import group_df_by_columns
 from .pivot_df import pivot_df
 from .melt_df import melt_df
+from .sort_df_by_index import sort_df_by_index
+from .shuffle_df_rows import shuffle_df_rows
 
 __all__ = [
     "dict_to_df",
@@ -50,4 +52,6 @@ __all__ = [
     "group_df_by_columns",
     "pivot_df",
     "melt_df",
+    "sort_df_by_index",
+    "shuffle_df_rows",
 ]

--- a/pandas_functions/shuffle_df_rows.py
+++ b/pandas_functions/shuffle_df_rows.py
@@ -1,0 +1,22 @@
+import pandas as pd
+
+
+def shuffle_df_rows(df: pd.DataFrame, random_state: int | None = None) -> pd.DataFrame:
+    """Shuffle rows of ``df``.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        DataFrame whose rows will be shuffled.
+    random_state : int | None, optional
+        Random seed for reproducibility. Defaults to ``None``.
+
+    Returns
+    -------
+    pd.DataFrame
+        Shuffled DataFrame with index reset.
+    """
+    return df.sample(frac=1, random_state=random_state).reset_index(drop=True)
+
+
+__all__ = ["shuffle_df_rows"]

--- a/pandas_functions/sort_df_by_index.py
+++ b/pandas_functions/sort_df_by_index.py
@@ -1,0 +1,22 @@
+import pandas as pd
+
+
+def sort_df_by_index(df: pd.DataFrame, ascending: bool = True) -> pd.DataFrame:
+    """Sort ``df`` by its index.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        DataFrame to sort by index.
+    ascending : bool, optional
+        Sort order. ``True`` for ascending, ``False`` for descending.
+
+    Returns
+    -------
+    pd.DataFrame
+        DataFrame sorted by index.
+    """
+    return df.sort_index(ascending=ascending)
+
+
+__all__ = ["sort_df_by_index"]

--- a/pytest/unit/pandas_functions/test_shuffle_df_rows.py
+++ b/pytest/unit/pandas_functions/test_shuffle_df_rows.py
@@ -1,0 +1,11 @@
+import pandas as pd
+
+from pandas_functions.shuffle_df_rows import shuffle_df_rows
+
+
+def test_shuffle_df_rows() -> None:
+    """Shuffling rows should change their order deterministically with a seed."""
+    df = pd.DataFrame({"A": [1, 2, 3]})
+    expected = pd.DataFrame({"A": [1, 3, 2]})
+    result = shuffle_df_rows(df, random_state=1)
+    pd.testing.assert_frame_equal(result, expected)

--- a/pytest/unit/pandas_functions/test_sort_df_by_index.py
+++ b/pytest/unit/pandas_functions/test_sort_df_by_index.py
@@ -1,0 +1,15 @@
+import pandas as pd
+
+from pandas_functions.sort_df_by_index import sort_df_by_index
+
+
+def test_sort_df_by_index() -> None:
+    """Sorting by index should reorder rows accordingly."""
+    df = pd.DataFrame({"A": [1, 2]}, index=[2, 1])
+    expected_asc = pd.DataFrame({"A": [2, 1]}, index=[1, 2])
+    result_asc = sort_df_by_index(df)
+    pd.testing.assert_frame_equal(result_asc, expected_asc)
+
+    expected_desc = pd.DataFrame({"A": [1, 2]}, index=[2, 1])
+    result_desc = sort_df_by_index(df, ascending=False)
+    pd.testing.assert_frame_equal(result_desc, expected_desc)


### PR DESCRIPTION
## Summary
- add `sort_df_by_index` to sort DataFrame by its index
- add `shuffle_df_rows` for deterministic row shuffling
- expose new helpers and cover them with tests

## Testing
- `pytest pytest/unit/pandas_functions/test_sort_df_by_index.py pytest/unit/pandas_functions/test_shuffle_df_rows.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a715bf8a188325bd6772a31c937b94