### PR TITLE
Add explode and split DataFrame column utilities

### DIFF
--- a/pandas_functions/__init__.py
+++ b/pandas_functions/__init__.py
@@ -25,6 +25,8 @@ from .pivot_df import pivot_df
 from .melt_df import melt_df
 from .sort_df_by_index import sort_df_by_index
 from .shuffle_df_rows import shuffle_df_rows
+from .explode_df_column import explode_df_column
+from .split_df_column import split_df_column
 
 __all__ = [
     "dict_to_df",
@@ -54,4 +56,6 @@ __all__ = [
     "melt_df",
     "sort_df_by_index",
     "shuffle_df_rows",
+    "explode_df_column",
+    "split_df_column",
 ]

--- a/pandas_functions/explode_df_column.py
+++ b/pandas_functions/explode_df_column.py
@@ -1,0 +1,29 @@
+import pandas as pd
+
+
+def explode_df_column(df: pd.DataFrame, column: str) -> pd.DataFrame:
+    """Explode a column containing list-like elements into separate rows.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        DataFrame to operate on.
+    column : str
+        Name of the column containing list-like objects to explode.
+
+    Returns
+    -------
+    pd.DataFrame
+        DataFrame with the specified column exploded and index reset.
+
+    Raises
+    ------
+    KeyError
+        If ``column`` is not present in ``df``.
+    """
+    if column not in df.columns:
+        raise KeyError(f"Column not found: {column}")
+    return df.explode(column, ignore_index=True)
+
+
+__all__ = ["explode_df_column"]

--- a/pandas_functions/split_df_column.py
+++ b/pandas_functions/split_df_column.py
@@ -1,0 +1,41 @@
+import pandas as pd
+from collections.abc import Iterable
+
+
+def split_df_column(df: pd.DataFrame, column: str, into: Iterable[str], sep: str) -> pd.DataFrame:
+    """Split a column into multiple new columns using a separator.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        DataFrame containing the column to split.
+    column : str
+        Name of the column to split.
+    into : Iterable[str]
+        Names of the columns to create from the split values.
+    sep : str
+        Separator used to split the column values.
+
+    Returns
+    -------
+    pd.DataFrame
+        DataFrame with the original column removed and new columns added.
+
+    Raises
+    ------
+    KeyError
+        If ``column`` is not present in ``df``.
+    ValueError
+        If the number of resulting columns does not match ``into``.
+    """
+    if column not in df.columns:
+        raise KeyError(f"Column not found: {column}")
+    into_list = list(into)
+    new_columns = df[column].astype(str).str.split(sep, expand=True)
+    if new_columns.shape[1] != len(into_list):
+        raise ValueError("Number of resulting columns does not match 'into'")
+    new_columns.columns = into_list
+    return df.drop(columns=[column]).join(new_columns)
+
+
+__all__ = ["split_df_column"]

--- a/pytest/unit/pandas_functions/test_explode_df_column.py
+++ b/pytest/unit/pandas_functions/test_explode_df_column.py
@@ -1,0 +1,17 @@
+import pandas as pd
+import pytest
+
+from pandas_functions.explode_df_column import explode_df_column
+
+
+def test_explode_df_column_basic() -> None:
+    df = pd.DataFrame({"id": [1, 2], "tags": [["a", "b"], ["c"]]})
+    result = explode_df_column(df, "tags")
+    expected = pd.DataFrame({"id": [1, 1, 2], "tags": ["a", "b", "c"]})
+    pd.testing.assert_frame_equal(result, expected)
+
+
+def test_explode_df_column_missing_column() -> None:
+    df = pd.DataFrame({"a": [1]})
+    with pytest.raises(KeyError):
+        explode_df_column(df, "missing")

--- a/pytest/unit/pandas_functions/test_split_df_column.py
+++ b/pytest/unit/pandas_functions/test_split_df_column.py
@@ -1,0 +1,23 @@
+import pandas as pd
+import pytest
+
+from pandas_functions.split_df_column import split_df_column
+
+
+def test_split_df_column_basic() -> None:
+    df = pd.DataFrame({"name": ["John Doe", "Jane Smith"], "age": [30, 25]})
+    result = split_df_column(df, "name", ["first", "last"], " ")
+    expected = pd.DataFrame({"age": [30, 25], "first": ["John", "Jane"], "last": ["Doe", "Smith"]})
+    pd.testing.assert_frame_equal(result, expected)
+
+
+def test_split_df_column_missing_column() -> None:
+    df = pd.DataFrame({"name": ["John Doe"]})
+    with pytest.raises(KeyError):
+        split_df_column(df, "missing", ["first", "last"], " ")
+
+
+def test_split_df_column_mismatch_into() -> None:
+    df = pd.DataFrame({"name": ["John Doe"], "age": [30]})
+    with pytest.raises(ValueError):
+        split_df_column(df, "name", ["first", "middle", "last"], " ")


### PR DESCRIPTION
## Summary
- add `explode_df_column` to expand list-like entries into rows
- add `split_df_column` to divide a string column into multiple columns
- include unit tests and expose helpers via `pandas_functions` package

## Testing
- `pytest pytest/unit/pandas_functions/test_explode_df_column.py pytest/unit/pandas_functions/test_split_df_column.py -q`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a74375c6208325aba0be47171429ba