### PR TITLE
Add NumPy array utilities and tests

### DIFF
--- a/numpy_functions/__init__.py
+++ b/numpy_functions/__init__.py
@@ -1,0 +1,4 @@
+from .array_mean import array_mean
+from .dot_product import dot_product
+
+__all__ = ["array_mean", "dot_product"]

--- a/numpy_functions/array_mean.py
+++ b/numpy_functions/array_mean.py
@@ -1,0 +1,33 @@
+import numpy as np
+
+
+def array_mean(arr: np.ndarray) -> float:
+    """
+    Compute the arithmetic mean of all elements in a NumPy array.
+
+    Parameters
+    ----------
+    arr : np.ndarray
+        Array containing numerical values.
+
+    Returns
+    -------
+    float
+        The mean of all elements in the array.
+
+    Raises
+    ------
+    TypeError
+        If `arr` is not a NumPy ndarray.
+
+    Examples
+    --------
+    >>> array_mean(np.array([1, 2, 3, 4]))
+    2.5
+    """
+    if not isinstance(arr, np.ndarray):
+        raise TypeError("arr must be a numpy.ndarray.")
+    return float(np.mean(arr))
+
+
+__all__ = ["array_mean"]

--- a/numpy_functions/dot_product.py
+++ b/numpy_functions/dot_product.py
@@ -1,0 +1,39 @@
+import numpy as np
+
+
+def dot_product(arr1: np.ndarray, arr2: np.ndarray) -> float:
+    """
+    Compute the dot product of two one-dimensional NumPy arrays.
+
+    Parameters
+    ----------
+    arr1 : np.ndarray
+        The first input array.
+    arr2 : np.ndarray
+        The second input array.
+
+    Returns
+    -------
+    float
+        The dot product of the two arrays.
+
+    Raises
+    ------
+    TypeError
+        If either input is not a NumPy ndarray.
+    ValueError
+        If the arrays are not one-dimensional or have different shapes.
+
+    Examples
+    --------
+    >>> dot_product(np.array([1, 2, 3]), np.array([4, 5, 6]))
+    32.0
+    """
+    if not isinstance(arr1, np.ndarray) or not isinstance(arr2, np.ndarray):
+        raise TypeError("Both inputs must be numpy.ndarray.")
+    if arr1.ndim != 1 or arr2.ndim != 1 or arr1.shape != arr2.shape:
+        raise ValueError("Arrays must be one-dimensional with the same shape.")
+    return float(np.dot(arr1, arr2))
+
+
+__all__ = ["dot_product"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "zstandard==0.23.0",
     "psutil==7.0.0",
     "tqdm==4.67.1",
+    "numpy==2.3.2",
     "aiohttp==3.12.15",
     "pandas==2.3.1",
 ]

--- a/pytest/unit/numpy_functions/test_array_mean.py
+++ b/pytest/unit/numpy_functions/test_array_mean.py
@@ -1,0 +1,28 @@
+import numpy as np
+import pytest
+from numpy_functions.array_mean import array_mean
+
+
+def test_array_mean_basic() -> None:
+    """
+    Test the array_mean function with positive integers.
+    """
+    # Test case 1: Positive integers
+    assert array_mean(np.array([1, 2, 3, 4])) == 2.5, "Failed on positive integers"
+
+
+def test_array_mean_negative() -> None:
+    """
+    Test the array_mean function with negative numbers.
+    """
+    # Test case 2: Negative numbers
+    assert array_mean(np.array([-1, -2, -3])) == -2.0, "Failed on negative numbers"
+
+
+def test_array_mean_invalid_type() -> None:
+    """
+    Test the array_mean function with an invalid input type.
+    """
+    # Test case 3: Invalid input type
+    with pytest.raises(TypeError):
+        array_mean([1, 2, 3])

--- a/pytest/unit/numpy_functions/test_dot_product.py
+++ b/pytest/unit/numpy_functions/test_dot_product.py
@@ -1,0 +1,37 @@
+import numpy as np
+import pytest
+from numpy_functions.dot_product import dot_product
+
+
+def test_dot_product_basic() -> None:
+    """
+    Test the dot_product function with basic one-dimensional arrays.
+    """
+    # Test case 1: Basic arrays
+    assert dot_product(np.array([1, 2, 3]), np.array([4, 5, 6])) == 32.0, "Failed on basic arrays"
+
+
+def test_dot_product_zero() -> None:
+    """
+    Test the dot_product function with arrays containing zeros.
+    """
+    # Test case 2: Arrays with zeros
+    assert dot_product(np.array([0, 0]), np.array([0, 0])) == 0.0, "Failed on zero arrays"
+
+
+def test_dot_product_mismatched_shapes() -> None:
+    """
+    Test the dot_product function with arrays of mismatched shapes.
+    """
+    # Test case 3: Mismatched shapes
+    with pytest.raises(ValueError):
+        dot_product(np.array([1, 2]), np.array([1, 2, 3]))
+
+
+def test_dot_product_invalid_type() -> None:
+    """
+    Test the dot_product function with an invalid input type.
+    """
+    # Test case 4: Invalid input type
+    with pytest.raises(TypeError):
+        dot_product([1, 2, 3], np.array([1, 2, 3]))

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,6 @@ python-snappy==0.7.3
 zstandard==0.23.0
 psutil==7.0.0
 tqdm==4.67.1
+numpy==2.3.2
 aiohttp==3.12.15
 pandas==2.3.1


### PR DESCRIPTION
## Summary
- implement `array_mean` to compute the mean of NumPy arrays
- add `dot_product` for validated one-dimensional array multiplication
- expose new utilities and declare NumPy dependency

## Testing
- `pytest pytest/unit/numpy_functions -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7492bfda4832590ff7f719c0c6ab7