### PR TITLE
Add DataFrame helpers and improve merge validation

### DIFF
--- a/pandas_functions/__init__.py
+++ b/pandas_functions/__init__.py
@@ -5,9 +5,12 @@ from .merge_dataframes import merge_dataframes
 from .df_to_dict import df_to_dict
 from .select_df_columns import select_df_columns
 from .sort_df_by_columns import sort_df_by_columns
+from .sort_df_columns import sort_df_columns
 from .fill_na_in_column import fill_na_in_column
 from .drop_df_columns import drop_df_columns
+from .drop_df_rows import drop_df_rows
 from .rename_df_columns import rename_df_columns
+from .rename_df_index import rename_df_index
 from .concat_dataframes import concat_dataframes
 from .apply_function_to_column import apply_function_to_column
 from .drop_na_df_rows import drop_na_df_rows
@@ -36,9 +39,12 @@ __all__ = [
     "df_to_dict",
     "select_df_columns",
     "sort_df_by_columns",
+    "sort_df_columns",
     "fill_na_in_column",
     "drop_df_columns",
+    "drop_df_rows",
     "rename_df_columns",
+    "rename_df_index",
     "concat_dataframes",
     "apply_function_to_column",
     "drop_na_df_rows",

--- a/pandas_functions/drop_df_rows.py
+++ b/pandas_functions/drop_df_rows.py
@@ -1,0 +1,32 @@
+import pandas as pd
+from collections.abc import Iterable
+
+
+def drop_df_rows(df: pd.DataFrame, indices: Iterable[object]) -> pd.DataFrame:
+    """Return ``df`` with specified index labels removed.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        DataFrame to drop rows from.
+    indices : Iterable[object]
+        Index labels to remove.
+
+    Returns
+    -------
+    pd.DataFrame
+        A DataFrame without the specified rows.
+
+    Raises
+    ------
+    KeyError
+        If any of ``indices`` are not present in ``df.index``.
+    """
+    indices_list = list(indices)
+    missing = set(indices_list) - set(df.index)
+    if missing:
+        raise KeyError(f"Index labels not found: {missing}")
+    return df.drop(index=indices_list)
+
+
+__all__ = ["drop_df_rows"]

--- a/pandas_functions/merge_dataframes.py
+++ b/pandas_functions/merge_dataframes.py
@@ -2,7 +2,7 @@ import pandas as pd
 
 
 def merge_dataframes(df1: pd.DataFrame, df2: pd.DataFrame, on: str, how: str = "inner") -> pd.DataFrame:
-    """Merge two pandas DataFrames.
+    """Merge two pandas DataFrames on a common column.
 
     Parameters
     ----------
@@ -13,13 +13,23 @@ def merge_dataframes(df1: pd.DataFrame, df2: pd.DataFrame, on: str, how: str = "
     on : str
         Column name to join on.
     how : str, optional
-        Type of merge to perform, by default "inner".
+        Type of merge to perform, by default ``"inner"``.
 
     Returns
     -------
     pd.DataFrame
         The merged DataFrame.
+
+    Raises
+    ------
+    KeyError
+        If ``on`` is not present in both ``df1`` and ``df2``.
     """
+
+    if on not in df1.columns:
+        raise KeyError(f"Column '{on}' not found in first DataFrame")
+    if on not in df2.columns:
+        raise KeyError(f"Column '{on}' not found in second DataFrame")
     return pd.merge(df1, df2, on=on, how=how)
 
 

--- a/pandas_functions/rename_df_index.py
+++ b/pandas_functions/rename_df_index.py
@@ -1,0 +1,31 @@
+import pandas as pd
+from collections.abc import Hashable
+
+
+def rename_df_index(df: pd.DataFrame, index_map: dict[Hashable, Hashable]) -> pd.DataFrame:
+    """Rename index labels of ``df`` according to ``index_map``.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        DataFrame whose index will be renamed.
+    index_map : dict[Hashable, Hashable]
+        Mapping of existing index labels to new labels.
+
+    Returns
+    -------
+    pd.DataFrame
+        DataFrame with renamed index labels.
+
+    Raises
+    ------
+    KeyError
+        If any keys in ``index_map`` are not present in ``df.index``.
+    """
+    missing = set(index_map) - set(df.index)
+    if missing:
+        raise KeyError(f"Index labels not found: {missing}")
+    return df.rename(index=index_map)
+
+
+__all__ = ["rename_df_index"]

--- a/pandas_functions/sort_df_columns.py
+++ b/pandas_functions/sort_df_columns.py
@@ -1,0 +1,23 @@
+import pandas as pd
+
+
+def sort_df_columns(df: pd.DataFrame, ascending: bool = True) -> pd.DataFrame:
+    """Sort the columns of ``df`` alphabetically.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        DataFrame whose columns will be sorted.
+    ascending : bool, optional
+        Sort columns in ascending order, by default ``True``.
+
+    Returns
+    -------
+    pd.DataFrame
+        DataFrame with columns reordered alphabetically.
+    """
+    sorted_cols = sorted(df.columns, reverse=not ascending)
+    return df[sorted_cols]
+
+
+__all__ = ["sort_df_columns"]

--- a/pytest/unit/pandas_functions/test_drop_df_rows.py
+++ b/pytest/unit/pandas_functions/test_drop_df_rows.py
@@ -1,0 +1,19 @@
+import pandas as pd
+import pytest
+
+from pandas_functions.drop_df_rows import drop_df_rows
+
+
+def test_drop_df_rows() -> None:
+    """Dropping by index labels should remove those rows."""
+    df = pd.DataFrame({"A": [1, 2]}, index=["x", "y"])
+    result = drop_df_rows(df, ["x"])
+    expected = pd.DataFrame({"A": [2]}, index=["y"])
+    pd.testing.assert_frame_equal(result, expected)
+
+
+def test_drop_df_rows_missing_index() -> None:
+    """Dropping a non-existent index should raise KeyError."""
+    df = pd.DataFrame({"A": [1]}, index=["x"])
+    with pytest.raises(KeyError):
+        drop_df_rows(df, ["y"])

--- a/pytest/unit/pandas_functions/test_merge_dataframes.py
+++ b/pytest/unit/pandas_functions/test_merge_dataframes.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pandas as pd
+import pytest
 from pandas.testing import assert_frame_equal
 
 from pandas_functions.merge_dataframes import merge_dataframes
@@ -29,4 +30,12 @@ def test_merge_dataframes_outer():
 
     result = merge_dataframes(df1, df2, on="id", how="outer")
     assert_frame_equal(result, expected)
+
+
+def test_merge_dataframes_missing_on() -> None:
+    """Missing join column should raise KeyError."""
+    df1 = pd.DataFrame({"id": [1]})
+    df2 = pd.DataFrame({"other": [1]})
+    with pytest.raises(KeyError):
+        merge_dataframes(df1, df2, on="id")
 

--- a/pytest/unit/pandas_functions/test_rename_df_index.py
+++ b/pytest/unit/pandas_functions/test_rename_df_index.py
@@ -1,0 +1,19 @@
+import pandas as pd
+import pytest
+
+from pandas_functions.rename_df_index import rename_df_index
+
+
+def test_rename_df_index() -> None:
+    """Mapping should rename index labels."""
+    df = pd.DataFrame({"A": [1]}, index=["old"])
+    expected = pd.DataFrame({"A": [1]}, index=["new"])
+    result = rename_df_index(df, {"old": "new"})
+    pd.testing.assert_frame_equal(result, expected)
+
+
+def test_rename_df_index_missing_label() -> None:
+    """Missing labels should raise KeyError."""
+    df = pd.DataFrame({"A": [1]}, index=["old"])
+    with pytest.raises(KeyError):
+        rename_df_index(df, {"missing": "new"})

--- a/pytest/unit/pandas_functions/test_sort_df_columns.py
+++ b/pytest/unit/pandas_functions/test_sort_df_columns.py
@@ -1,0 +1,19 @@
+import pandas as pd
+
+from pandas_functions.sort_df_columns import sort_df_columns
+
+
+def test_sort_df_columns_ascending() -> None:
+    """Columns should be sorted alphabetically."""
+    df = pd.DataFrame({"B": [1], "A": [2]})
+    result = sort_df_columns(df)
+    expected = pd.DataFrame({"A": [2], "B": [1]})
+    pd.testing.assert_frame_equal(result, expected)
+
+
+def test_sort_df_columns_descending() -> None:
+    """Descending order should reverse column order."""
+    df = pd.DataFrame({"B": [1], "A": [2]})
+    result = sort_df_columns(df, ascending=False)
+    expected = pd.DataFrame({"B": [1], "A": [2]})
+    pd.testing.assert_frame_equal(result, expected)


### PR DESCRIPTION
## Summary
- add helpers to sort columns, drop rows, and rename DataFrame index
- validate merge column existence in `merge_dataframes`
- cover new functionality with unit tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a7483e8a5c83258b8de694a21ffccd