### PR TITLE
Add JSON utilities for file_functions

### DIFF
--- a/file_functions/__init__.py
+++ b/file_functions/__init__.py
@@ -12,7 +12,9 @@ from .join_paths import join_paths
 from .merge_folders import merge_folders
 from .read_lines import read_lines
 from .read_tabular import read_tabular
+from .json_to_dict import json_to_dict
 from .tsv_to_dict import tsv_to_dict
+from .write_dict_to_json import write_dict_to_json
 from .write_dict_to_tsv import write_dict_to_tsv
 from .write_lines import write_lines
 from .write_to_file import write_to_file
@@ -32,7 +34,9 @@ __all__ = [
     "merge_folders",
     "read_lines",
     "read_tabular",
+    "json_to_dict",
     "tsv_to_dict",
+    "write_dict_to_json",
     "write_dict_to_tsv",
     "write_lines",
     "write_to_file",

--- a/file_functions/json_to_dict.py
+++ b/file_functions/json_to_dict.py
@@ -1,0 +1,25 @@
+import json
+from typing import Any
+
+
+def json_to_dict(file_path: str) -> dict[str, Any]:
+    """
+    Read a JSON file and return its contents as a dictionary.
+
+    Parameters
+    ----------
+    file_path : str
+        Path to the JSON file.
+
+    Returns
+    -------
+    Dict[str, Any]
+        Dictionary representation of the JSON contents.
+    """
+    with open(file_path) as f:
+        data: dict[str, Any] = json.load(f)
+
+    return data
+
+
+__all__ = ["json_to_dict"]

--- a/file_functions/write_dict_to_json.py
+++ b/file_functions/write_dict_to_json.py
@@ -1,0 +1,28 @@
+import json
+from typing import Any
+
+
+def write_dict_to_json(
+    file_path: str, data: dict[str, Any], indent: int | None = None
+) -> None:
+    """
+    Write a dictionary to a JSON file.
+
+    Parameters
+    ----------
+    file_path : str
+        Path to the JSON file to write.
+    data : Dict[str, Any]
+        Dictionary to serialize and write to the file.
+    indent : Optional[int]
+        Number of spaces to use for indentation in the output file (default is None).
+
+    Returns
+    -------
+    None
+    """
+    with open(file_path, "w") as f:
+        json.dump(data, f, indent=indent)
+
+
+__all__ = ["write_dict_to_json"]

--- a/pytest/unit/file_functions/test_json_to_dict.py
+++ b/pytest/unit/file_functions/test_json_to_dict.py
@@ -1,0 +1,30 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from file_functions.json_to_dict import json_to_dict
+
+
+def test_json_to_dict_reads_valid_json(tmp_path: Path) -> None:
+    """Ensure valid JSON is parsed into a dictionary."""
+    data: dict[str, object] = {"a": 1, "b": [1, 2]}
+    file: Path = tmp_path / "sample.json"
+    file.write_text(json.dumps(data))
+    result: dict[str, object] = json_to_dict(str(file))
+    assert result == data
+
+
+def test_json_to_dict_empty_file_raises_jsondecodeerror(tmp_path: Path) -> None:
+    """Empty file should raise JSONDecodeError."""
+    file: Path = tmp_path / "empty.json"
+    file.write_text("")
+    with pytest.raises(json.JSONDecodeError):
+        json_to_dict(str(file))
+
+
+def test_json_to_dict_missing_file_raises_filenotfounderror(tmp_path: Path) -> None:
+    """Missing file should raise FileNotFoundError."""
+    missing_file: Path = tmp_path / "missing.json"
+    with pytest.raises(FileNotFoundError):
+        json_to_dict(str(missing_file))

--- a/pytest/unit/file_functions/test_write_dict_to_json.py
+++ b/pytest/unit/file_functions/test_write_dict_to_json.py
@@ -1,0 +1,35 @@
+import json
+from pathlib import Path
+
+import importlib
+import pytest
+
+wdj = importlib.import_module("file_functions.write_dict_to_json")
+
+
+def test_write_dict_to_json_writes_expected(tmp_path: Path) -> None:
+    """Ensure dictionary is correctly serialized to a JSON file."""
+    data: dict[str, object] = {"a": 1, "b": [1, 2]}
+    output_file: Path = tmp_path / "output.json"
+    wdj.write_dict_to_json(str(output_file), data, indent=2)
+    assert json.loads(output_file.read_text()) == data
+
+
+def test_write_dict_to_json_writes_empty_dict(tmp_path: Path) -> None:
+    """Ensure an empty dictionary produces an empty JSON object."""
+    output_file: Path = tmp_path / "output.json"
+    wdj.write_dict_to_json(str(output_file), {})
+    assert output_file.read_text() == "{}"
+
+
+def test_write_dict_to_json_raises_permission_error(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Ensure PermissionError is raised when the file cannot be written."""
+    data: dict[str, int] = {"a": 1}
+    file_path: Path = tmp_path / "output.json"
+
+    def mock_open(*args, **kwargs):
+        raise PermissionError("No permission")
+
+    monkeypatch.setattr("builtins.open", mock_open)
+    with pytest.raises(PermissionError):
+        wdj.write_dict_to_json(str(file_path), data)


### PR DESCRIPTION
## Summary
- add `json_to_dict` and `write_dict_to_json` utilities for working with JSON files
- expose new JSON helpers through `file_functions.__init__`
- cover JSON utilities with unit tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a74f3833508325803f85f686aaf016