### PR TITLE
Add elementwise product NumPy utility

### DIFF
--- a/numpy_functions/__init__.py
+++ b/numpy_functions/__init__.py
@@ -2,6 +2,7 @@ from .array_mean import array_mean
 from .array_variance import array_variance
 from .dot_product import dot_product
 from .elementwise_sum import elementwise_sum
+from .elementwise_product import elementwise_product
 from .matrix_multiply import matrix_multiply
 from .normalize_array import normalize_array
 
@@ -10,6 +11,7 @@ __all__ = [
     "array_variance",
     "dot_product",
     "elementwise_sum",
+    "elementwise_product",
     "matrix_multiply",
     "normalize_array",
 ]

--- a/numpy_functions/elementwise_product.py
+++ b/numpy_functions/elementwise_product.py
@@ -1,0 +1,39 @@
+import numpy as np
+
+
+def elementwise_product(arr1: np.ndarray, arr2: np.ndarray) -> np.ndarray:
+    """
+    Compute the element-wise product of two NumPy arrays.
+
+    Parameters
+    ----------
+    arr1 : np.ndarray
+        The first input array.
+    arr2 : np.ndarray
+        The second input array.
+
+    Returns
+    -------
+    np.ndarray
+        Array containing the element-wise product of ``arr1`` and ``arr2``.
+
+    Raises
+    ------
+    TypeError
+        If either input is not a NumPy ndarray.
+    ValueError
+        If the arrays do not have the same shape.
+
+    Examples
+    --------
+    >>> elementwise_product(np.array([1, 2]), np.array([3, 4]))
+    array([3, 8])
+    """
+    if not isinstance(arr1, np.ndarray) or not isinstance(arr2, np.ndarray):
+        raise TypeError("Both inputs must be numpy.ndarray.")
+    if arr1.shape != arr2.shape:
+        raise ValueError("Arrays must have the same shape.")
+    return np.multiply(arr1, arr2)
+
+
+__all__ = ["elementwise_product"]

--- a/pytest/unit/numpy_functions/test_elementwise_product.py
+++ b/pytest/unit/numpy_functions/test_elementwise_product.py
@@ -1,0 +1,31 @@
+import numpy as np
+import pytest
+from numpy_functions.elementwise_product import elementwise_product
+
+
+
+def test_elementwise_product_basic() -> None:
+    """
+    Test elementwise_product with arrays of the same shape.
+    """
+    result = elementwise_product(np.array([1, 2]), np.array([3, 4]))
+    expected = np.array([3, 8])
+    assert np.array_equal(result, expected), "Failed on basic element-wise product"
+
+
+
+def test_elementwise_product_mismatched_shapes() -> None:
+    """
+    Test elementwise_product with arrays of different shapes.
+    """
+    with pytest.raises(ValueError):
+        elementwise_product(np.array([1, 2]), np.array([1, 2, 3]))
+
+
+
+def test_elementwise_product_invalid_type() -> None:
+    """
+    Test elementwise_product with invalid input types.
+    """
+    with pytest.raises(TypeError):
+        elementwise_product([1, 2], np.array([1, 2]))


### PR DESCRIPTION
## Summary
- add `elementwise_product` NumPy helper for pairwise multiplication
- expose new helper in numpy_functions package
- cover with unit tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a75085ddc48325922c93545b02a533