### PR TITLE
Refactor pandas tests for consistent style

### DIFF
--- a/pytest/unit/pandas_functions/test_add_prefix_to_df_columns.py
+++ b/pytest/unit/pandas_functions/test_add_prefix_to_df_columns.py
@@ -1,11 +1,24 @@
 import pandas as pd
+import pytest
 
 from pandas_functions.add_prefix_to_df_columns import add_prefix_to_df_columns
 
 
 def test_add_prefix_to_df_columns() -> None:
-    """Adding a prefix should rename all columns."""
+    """
+    Test adding a prefix to DataFrame columns.
+    """
+    # Test case 1: Adds prefix to each column
     df = pd.DataFrame({"A": [1], "B": [2]})
     expected = pd.DataFrame({"pre_A": [1], "pre_B": [2]})
     result = add_prefix_to_df_columns(df, "pre_")
     pd.testing.assert_frame_equal(result, expected)
+
+
+def test_add_prefix_to_df_columns_invalid_input() -> None:
+    """
+    Ensure passing a non-DataFrame raises ``AttributeError``.
+    """
+    # Test case 2: Invalid DataFrame input
+    with pytest.raises(AttributeError):
+        add_prefix_to_df_columns("not a df", "pre_")

--- a/pytest/unit/pandas_functions/test_add_suffix_to_df_columns.py
+++ b/pytest/unit/pandas_functions/test_add_suffix_to_df_columns.py
@@ -1,11 +1,24 @@
 import pandas as pd
+import pytest
 
 from pandas_functions.add_suffix_to_df_columns import add_suffix_to_df_columns
 
 
 def test_add_suffix_to_df_columns() -> None:
-    """Adding a suffix should rename all columns."""
+    """
+    Test adding a suffix to DataFrame columns.
+    """
+    # Test case 1: Adds suffix to each column
     df = pd.DataFrame({"A": [1], "B": [2]})
     expected = pd.DataFrame({"A_suf": [1], "B_suf": [2]})
     result = add_suffix_to_df_columns(df, "_suf")
     pd.testing.assert_frame_equal(result, expected)
+
+
+def test_add_suffix_to_df_columns_invalid_input() -> None:
+    """
+    Ensure passing a non-DataFrame raises ``AttributeError``.
+    """
+    # Test case 2: Invalid DataFrame input
+    with pytest.raises(AttributeError):
+        add_suffix_to_df_columns("not a df", "_suf")

--- a/pytest/unit/pandas_functions/test_all_match_series.py
+++ b/pytest/unit/pandas_functions/test_all_match_series.py
@@ -6,6 +6,7 @@ from pandas_functions import all_match_series
 
 def test_all_match_series_success() -> None:
     """Test the ``all_match_series`` function when all elements match."""
+    # Test case 1: All elements match
     series1: pd.Series = pd.Series([1, 2, 3])
     series2: pd.Series = pd.Series([1, 2, 3, 4, 5])
     assert all_match_series(series1, series2) is True
@@ -13,6 +14,7 @@ def test_all_match_series_success() -> None:
 
 def test_all_match_series_partial_match() -> None:
     """Test the ``all_match_series`` function when not all elements match."""
+    # Test case 2: Partial match
     series1: pd.Series = pd.Series([1, 2, 6])
     series2: pd.Series = pd.Series([1, 2, 3, 4, 5])
     assert all_match_series(series1, series2) is False
@@ -20,6 +22,7 @@ def test_all_match_series_partial_match() -> None:
 
 def test_all_match_series_empty_series1() -> None:
     """Test with an empty ``series1``."""
+    # Test case 3: Empty series1
     series1: pd.Series = pd.Series([], dtype=int)
     series2: pd.Series = pd.Series([1, 2, 3])
     assert all_match_series(series1, series2) is True
@@ -27,6 +30,7 @@ def test_all_match_series_empty_series1() -> None:
 
 def test_all_match_series_empty_series2() -> None:
     """Test with an empty ``series2``."""
+    # Test case 4: Empty series2
     series1: pd.Series = pd.Series([1, 2, 3])
     series2: pd.Series = pd.Series([], dtype=int)
     assert all_match_series(series1, series2) is False
@@ -34,6 +38,7 @@ def test_all_match_series_empty_series2() -> None:
 
 def test_all_match_series_two_empty_series() -> None:
     """Test with both ``series1`` and ``series2`` empty."""
+    # Test case 5: Both series empty
     series1: pd.Series = pd.Series([], dtype=int)
     series2: pd.Series = pd.Series([], dtype=int)
     assert all_match_series(series1, series2) is True
@@ -41,6 +46,7 @@ def test_all_match_series_two_empty_series() -> None:
 
 def test_all_match_series_strings() -> None:
     """Test the function with string values."""
+    # Test case 6: String values
     series1: pd.Series = pd.Series(["apple", "banana"])
     series2: pd.Series = pd.Series(["apple", "banana", "cherry"])
     assert all_match_series(series1, series2) is True
@@ -48,6 +54,7 @@ def test_all_match_series_strings() -> None:
 
 def test_all_match_series_mixed_types() -> None:
     """Test the function with mixed data types."""
+    # Test case 7: Mixed data types
     series1: pd.Series = pd.Series([1, "banana", 3.14])
     series2: pd.Series = pd.Series([1, "banana", 3.14, "apple"])
     assert all_match_series(series1, series2) is True
@@ -55,6 +62,7 @@ def test_all_match_series_mixed_types() -> None:
 
 def test_all_match_series_unhashable_elements() -> None:
     """Test the function with unhashable elements such as lists."""
+    # Test case 8: Unhashable elements
     series1: pd.Series = pd.Series([[1, 2], [3, 4]])
     series2: pd.Series = pd.Series([[1, 2], [3, 4], [5, 6]])
     assert all_match_series(series1, series2) is True
@@ -62,11 +70,13 @@ def test_all_match_series_unhashable_elements() -> None:
 
 def test_all_match_series_type_error_series1() -> None:
     """Ensure a ``TypeError`` is raised when ``series1`` is invalid."""
+    # Test case 9: Invalid series1
     with pytest.raises(TypeError):
         all_match_series("not a series", pd.Series([1, 2, 3]))
 
 
 def test_all_match_series_type_error_series2() -> None:
     """Ensure a ``TypeError`` is raised when ``series2`` is invalid."""
+    # Test case 10: Invalid series2
     with pytest.raises(TypeError):
         all_match_series(pd.Series([1, 2, 3]), "not a series")

--- a/pytest/unit/pandas_functions/test_apply_function_to_column.py
+++ b/pytest/unit/pandas_functions/test_apply_function_to_column.py
@@ -4,14 +4,31 @@ import pytest
 from pandas_functions import apply_function_to_column
 
 
-def test_apply_function_to_column():
+def test_apply_function_to_column() -> None:
+    """
+    Test applying a function to a DataFrame column.
+    """
+    # Test case 1: Apply lambda to column
     df = pd.DataFrame({"A": [1, 2, 3]})
     result = apply_function_to_column(df, "A", lambda x: x * 2)
     expected = pd.DataFrame({"A": [2, 4, 6]})
     pd.testing.assert_frame_equal(result, expected)
 
 
-def test_apply_function_to_column_missing():
+def test_apply_function_to_column_missing() -> None:
+    """
+    Ensure missing column raises ``KeyError``.
+    """
+    # Test case 2: Missing column
     df = pd.DataFrame({"A": [1]})
     with pytest.raises(KeyError):
         apply_function_to_column(df, "B", lambda x: x)
+
+
+def test_apply_function_to_column_invalid_df() -> None:
+    """
+    Ensure passing a non-DataFrame raises ``AttributeError``.
+    """
+    # Test case 3: Invalid DataFrame input
+    with pytest.raises(AttributeError):
+        apply_function_to_column("not a df", "A", lambda x: x)

--- a/pytest/unit/pandas_functions/test_concat_dataframes.py
+++ b/pytest/unit/pandas_functions/test_concat_dataframes.py
@@ -4,7 +4,11 @@ import pytest
 from pandas_functions import concat_dataframes
 
 
-def test_concat_dataframes():
+def test_concat_dataframes() -> None:
+    """
+    Concatenating DataFrames should combine their rows.
+    """
+    # Test case 1: Basic concatenation
     df1 = pd.DataFrame({"A": [1, 2]})
     df2 = pd.DataFrame({"A": [3]})
     result = concat_dataframes([df1, df2])
@@ -12,12 +16,20 @@ def test_concat_dataframes():
     pd.testing.assert_frame_equal(result.reset_index(drop=True), expected)
 
 
-def test_concat_dataframes_type_error():
+def test_concat_dataframes_type_error() -> None:
+    """
+    Passing a non-DataFrame should raise ``TypeError``.
+    """
+    # Test case 2: Invalid DataFrame in list
     df1 = pd.DataFrame({"A": [1]})
     with pytest.raises(TypeError):
         concat_dataframes([df1, "not a df"])
 
 
-def test_concat_dataframes_empty():
+def test_concat_dataframes_empty() -> None:
+    """
+    An empty list of DataFrames should raise ``ValueError``.
+    """
+    # Test case 3: Empty input list
     with pytest.raises(ValueError):
         concat_dataframes([])

--- a/pytest/unit/pandas_functions/test_convert_df_column_dtype.py
+++ b/pytest/unit/pandas_functions/test_convert_df_column_dtype.py
@@ -5,7 +5,10 @@ from pandas_functions.convert_df_column_dtype import convert_df_column_dtype
 
 
 def test_convert_df_column_dtype() -> None:
-    """Converting a column should change its dtype."""
+    """
+    Converting a column should change its dtype.
+    """
+    # Test case 1: Convert str to int
     df = pd.DataFrame({"A": ["1", "2"]})
     result = convert_df_column_dtype(df, "A", int)
     expected = pd.DataFrame({"A": [1, 2]})
@@ -13,7 +16,19 @@ def test_convert_df_column_dtype() -> None:
 
 
 def test_convert_df_column_dtype_missing() -> None:
-    """Requesting a missing column should raise ``KeyError``."""
+    """
+    Requesting a missing column should raise ``KeyError``.
+    """
+    # Test case 2: Missing column
     df = pd.DataFrame({"A": [1]})
     with pytest.raises(KeyError):
         convert_df_column_dtype(df, "B", int)
+
+
+def test_convert_df_column_dtype_invalid_df() -> None:
+    """
+    Ensure passing a non-DataFrame raises ``AttributeError``.
+    """
+    # Test case 3: Invalid DataFrame input
+    with pytest.raises(AttributeError):
+        convert_df_column_dtype("not a df", "A", int)

--- a/pytest/unit/pandas_functions/test_df_to_dict.py
+++ b/pytest/unit/pandas_functions/test_df_to_dict.py
@@ -5,20 +5,29 @@ from pandas_functions.df_to_dict import df_to_dict
 
 
 def test_df_to_dict_default() -> None:
-    """DataFrame should convert to nested dict with default orientation."""
+    """
+    DataFrame should convert to nested dict with default orientation.
+    """
+    # Test case 1: Default orientation
     df: pd.DataFrame = pd.DataFrame({"col1": [1, 2], "col2": [3, 4]})
     expected: dict = {"col1": {0: 1, 1: 2}, "col2": {0: 3, 1: 4}}
     assert df_to_dict(df) == expected
 
 
 def test_df_to_dict_list_orient() -> None:
-    """DataFrame should convert to list-oriented dictionary."""
+    """
+    DataFrame should convert to list-oriented dictionary.
+    """
+    # Test case 2: List orientation
     df: pd.DataFrame = pd.DataFrame({"col1": [1, 2], "col2": [3, 4]})
     expected: dict = {"col1": [1, 2], "col2": [3, 4]}
     assert df_to_dict(df, orient="list") == expected
 
 
 def test_df_to_dict_invalid_input() -> None:
-    """Passing a non-DataFrame should raise a TypeError."""
+    """
+    Passing a non-DataFrame should raise a ``TypeError``.
+    """
+    # Test case 3: Invalid DataFrame input
     with pytest.raises(TypeError):
         df_to_dict({"col1": [1, 2]})

--- a/pytest/unit/pandas_functions/test_drop_df_columns.py
+++ b/pytest/unit/pandas_functions/test_drop_df_columns.py
@@ -5,7 +5,10 @@ from pandas_functions.drop_df_columns import drop_df_columns
 
 
 def test_drop_df_columns() -> None:
-    """Dropping specified columns should remove them from the DataFrame."""
+    """
+    Dropping specified columns should remove them from the DataFrame.
+    """
+    # Test case 1: Drop existing column
     df = pd.DataFrame({"A": [1, 2], "B": [3, 4], "C": [5, 6]})
     expected = pd.DataFrame({"A": [1, 2], "C": [5, 6]})
     result = drop_df_columns(df, ["B"])
@@ -13,7 +16,19 @@ def test_drop_df_columns() -> None:
 
 
 def test_drop_df_columns_missing() -> None:
-    """Dropping a non-existent column should raise ``KeyError``."""
+    """
+    Dropping a non-existent column should raise ``KeyError``.
+    """
+    # Test case 2: Missing column
     df = pd.DataFrame({"A": [1, 2]})
     with pytest.raises(KeyError):
         drop_df_columns(df, ["B"])
+
+
+def test_drop_df_columns_invalid_df() -> None:
+    """
+    Ensure passing a non-DataFrame raises ``AttributeError``.
+    """
+    # Test case 3: Invalid DataFrame input
+    with pytest.raises(AttributeError):
+        drop_df_columns("not a df", ["A"])

--- a/pytest/unit/pandas_functions/test_drop_df_rows.py
+++ b/pytest/unit/pandas_functions/test_drop_df_rows.py
@@ -5,7 +5,10 @@ from pandas_functions.drop_df_rows import drop_df_rows
 
 
 def test_drop_df_rows() -> None:
-    """Dropping by index labels should remove those rows."""
+    """
+    Dropping by index labels should remove those rows.
+    """
+    # Test case 1: Drop existing index
     df = pd.DataFrame({"A": [1, 2]}, index=["x", "y"])
     result = drop_df_rows(df, ["x"])
     expected = pd.DataFrame({"A": [2]}, index=["y"])
@@ -13,7 +16,19 @@ def test_drop_df_rows() -> None:
 
 
 def test_drop_df_rows_missing_index() -> None:
-    """Dropping a non-existent index should raise KeyError."""
+    """
+    Dropping a non-existent index should raise ``KeyError``.
+    """
+    # Test case 2: Missing index
     df = pd.DataFrame({"A": [1]}, index=["x"])
     with pytest.raises(KeyError):
         drop_df_rows(df, ["y"])
+
+
+def test_drop_df_rows_invalid_df() -> None:
+    """
+    Ensure passing a non-DataFrame raises ``AttributeError``.
+    """
+    # Test case 3: Invalid DataFrame input
+    with pytest.raises(AttributeError):
+        drop_df_rows("not a df", ["x"])

--- a/pytest/unit/pandas_functions/test_drop_duplicate_df_rows.py
+++ b/pytest/unit/pandas_functions/test_drop_duplicate_df_rows.py
@@ -5,7 +5,10 @@ from pandas_functions.drop_duplicate_df_rows import drop_duplicate_df_rows
 
 
 def test_drop_duplicate_df_rows() -> None:
-    """Duplicate rows should be removed."""
+    """
+    Duplicate rows should be removed.
+    """
+    # Test case 1: Drop duplicate rows
     df = pd.DataFrame({"A": [1, 1, 2], "B": [3, 3, 4]})
     expected = pd.DataFrame({"A": [1, 2], "B": [3, 4]})
     result = drop_duplicate_df_rows(df)
@@ -13,7 +16,19 @@ def test_drop_duplicate_df_rows() -> None:
 
 
 def test_drop_duplicate_df_rows_invalid_keep() -> None:
-    """Invalid ``keep`` value should raise ``ValueError``."""
+    """
+    Invalid ``keep`` value should raise ``ValueError``.
+    """
+    # Test case 2: Invalid keep parameter
     df = pd.DataFrame({"A": [1, 1]})
     with pytest.raises(ValueError):
         drop_duplicate_df_rows(df, keep="invalid")
+
+
+def test_drop_duplicate_df_rows_invalid_df() -> None:
+    """
+    Ensure passing a non-DataFrame raises ``AttributeError``.
+    """
+    # Test case 3: Invalid DataFrame input
+    with pytest.raises(AttributeError):
+        drop_duplicate_df_rows("not a df")

--- a/pytest/unit/pandas_functions/test_drop_na_df_columns.py
+++ b/pytest/unit/pandas_functions/test_drop_na_df_columns.py
@@ -1,10 +1,14 @@
 import pandas as pd
+import pytest
 
 from pandas_functions.drop_na_df_columns import drop_na_df_columns
 
 
 def test_drop_na_df_columns_any() -> None:
-    """Columns with any NA values should be dropped by default."""
+    """
+    Columns with any NA values should be dropped by default.
+    """
+    # Test case 1: Drop columns with any NA
     df = pd.DataFrame({"A": [1, 2], "B": [None, None], "C": [1, None]})
     result = drop_na_df_columns(df)
     expected = pd.DataFrame({"A": [1, 2]})
@@ -12,8 +16,21 @@ def test_drop_na_df_columns_any() -> None:
 
 
 def test_drop_na_df_columns_all() -> None:
-    """Using ``how='all'`` should only drop columns with all NA values."""
+    """
+    Using ``how='all'`` should only drop columns with all NA values.
+    """
+    # Test case 2: Drop columns with all NA
     df = pd.DataFrame({"A": [1, 2], "B": [None, None], "C": [1, None]})
     result = drop_na_df_columns(df, how="all")
     expected = pd.DataFrame({"A": [1, 2], "C": [1, None]})
     pd.testing.assert_frame_equal(result, expected)
+
+
+def test_drop_na_df_columns_invalid_how() -> None:
+    """
+    Invalid ``how`` value should raise ``ValueError``.
+    """
+    # Test case 3: Invalid how parameter
+    df = pd.DataFrame({"A": [1]})
+    with pytest.raises(ValueError):
+        drop_na_df_columns(df, how="invalid")

--- a/pytest/unit/pandas_functions/test_drop_na_df_rows.py
+++ b/pytest/unit/pandas_functions/test_drop_na_df_rows.py
@@ -4,21 +4,42 @@ import pytest
 from pandas_functions import drop_na_df_rows
 
 
-def test_drop_na_df_rows_subset():
+def test_drop_na_df_rows_subset() -> None:
+    """
+    Rows with NA in specified subset should be dropped.
+    """
+    # Test case 1: Drop NA based on subset
     df = pd.DataFrame({"A": [1, None, 2], "B": [4, 5, None]})
     result = drop_na_df_rows(df, ["A"])
     expected = pd.DataFrame({"A": [1.0, 2.0], "B": [4.0, None]})
     pd.testing.assert_frame_equal(result.reset_index(drop=True), expected)
 
 
-def test_drop_na_df_rows_all_columns():
+def test_drop_na_df_rows_all_columns() -> None:
+    """
+    Rows with NA in any column should be dropped when no subset is provided.
+    """
+    # Test case 2: Drop NA from all columns
     df = pd.DataFrame({"A": [1, None], "B": [4, 5]})
     result = drop_na_df_rows(df)
     expected = pd.DataFrame({"A": [1.0], "B": [4]})
     pd.testing.assert_frame_equal(result.reset_index(drop=True), expected)
 
 
-def test_drop_na_df_rows_missing_column():
+def test_drop_na_df_rows_missing_column() -> None:
+    """
+    Requesting a missing column should raise ``KeyError``.
+    """
+    # Test case 3: Missing column
     df = pd.DataFrame({"A": [1, None]})
     with pytest.raises(KeyError):
         drop_na_df_rows(df, ["B"])
+
+
+def test_drop_na_df_rows_invalid_df() -> None:
+    """
+    Ensure passing a non-DataFrame raises ``AttributeError``.
+    """
+    # Test case 4: Invalid DataFrame input
+    with pytest.raises(AttributeError):
+        drop_na_df_rows("not a df", ["A"])

--- a/pytest/unit/pandas_functions/test_explode_df_column.py
+++ b/pytest/unit/pandas_functions/test_explode_df_column.py
@@ -5,6 +5,10 @@ from pandas_functions.explode_df_column import explode_df_column
 
 
 def test_explode_df_column_basic() -> None:
+    """
+    Exploding a column with lists should create multiple rows.
+    """
+    # Test case 1: Basic explosion
     df = pd.DataFrame({"id": [1, 2], "tags": [["a", "b"], ["c"]]})
     result = explode_df_column(df, "tags")
     expected = pd.DataFrame({"id": [1, 1, 2], "tags": ["a", "b", "c"]})
@@ -12,6 +16,19 @@ def test_explode_df_column_basic() -> None:
 
 
 def test_explode_df_column_missing_column() -> None:
+    """
+    Requesting a missing column should raise ``KeyError``.
+    """
+    # Test case 2: Missing column
     df = pd.DataFrame({"a": [1]})
     with pytest.raises(KeyError):
         explode_df_column(df, "missing")
+
+
+def test_explode_df_column_invalid_df() -> None:
+    """
+    Ensure passing a non-DataFrame raises ``AttributeError``.
+    """
+    # Test case 3: Invalid DataFrame input
+    with pytest.raises(AttributeError):
+        explode_df_column("not a df", "tags")

--- a/pytest/unit/pandas_functions/test_fill_na_in_column.py
+++ b/pytest/unit/pandas_functions/test_fill_na_in_column.py
@@ -6,7 +6,10 @@ from pandas_functions.fill_na_in_column import fill_na_in_column
 
 
 def test_fill_na_in_column() -> None:
-    """NaN values in the specified column should be replaced."""
+    """
+    NaN values in the specified column should be replaced.
+    """
+    # Test case 1: Fill NaNs in column
     df = pd.DataFrame({"A": [1, np.nan, 3]})
     expected = pd.DataFrame({"A": [1.0, 0.0, 3.0]})
     result = fill_na_in_column(df, "A", 0)
@@ -14,8 +17,20 @@ def test_fill_na_in_column() -> None:
 
 
 def test_fill_na_in_column_missing_column() -> None:
-    """Passing an invalid column name should raise ``KeyError``."""
+    """
+    Passing an invalid column name should raise ``KeyError``.
+    """
+    # Test case 2: Missing column
     df = pd.DataFrame({"A": [1, 2]})
     with pytest.raises(KeyError):
         fill_na_in_column(df, "B", 0)
+
+
+def test_fill_na_in_column_invalid_df() -> None:
+    """
+    Ensure passing a non-DataFrame raises ``AttributeError``.
+    """
+    # Test case 3: Invalid DataFrame input
+    with pytest.raises(AttributeError):
+        fill_na_in_column("not a df", "A", 0)
 

--- a/pytest/unit/pandas_functions/test_filter_df_by_column_value.py
+++ b/pytest/unit/pandas_functions/test_filter_df_by_column_value.py
@@ -4,14 +4,31 @@ import pytest
 from pandas_functions import filter_df_by_column_value
 
 
-def test_filter_df_by_column_value():
+def test_filter_df_by_column_value() -> None:
+    """
+    Filtering by a column value should return matching rows.
+    """
+    # Test case 1: Filter rows by value
     df = pd.DataFrame({"A": [1, 2, 1], "B": ["x", "y", "z"]})
     expected = pd.DataFrame({"A": [1, 1], "B": ["x", "z"]})
     result = filter_df_by_column_value(df, "A", 1)
     pd.testing.assert_frame_equal(result.reset_index(drop=True), expected)
 
 
-def test_filter_df_by_column_value_missing_column():
+def test_filter_df_by_column_value_missing_column() -> None:
+    """
+    Filtering with a missing column should raise ``KeyError``.
+    """
+    # Test case 2: Missing column
     df = pd.DataFrame({"A": [1, 2, 3]})
     with pytest.raises(KeyError):
         filter_df_by_column_value(df, "B", 1)
+
+
+def test_filter_df_by_column_value_invalid_df() -> None:
+    """
+    Ensure passing a non-DataFrame raises ``AttributeError``.
+    """
+    # Test case 3: Invalid DataFrame input
+    with pytest.raises(AttributeError):
+        filter_df_by_column_value("not a df", "A", 1)

--- a/pytest/unit/pandas_functions/test_filter_df_by_column_values.py
+++ b/pytest/unit/pandas_functions/test_filter_df_by_column_values.py
@@ -5,7 +5,10 @@ from pandas_functions.filter_df_by_column_values import filter_df_by_column_valu
 
 
 def test_filter_df_by_column_values() -> None:
-    """Filtering by multiple values should return matching rows."""
+    """
+    Filtering by multiple values should return matching rows.
+    """
+    # Test case 1: Filter rows by multiple values
     df = pd.DataFrame({"A": [1, 2, 3], "B": ["x", "y", "z"]})
     expected = pd.DataFrame({"A": [1, 3], "B": ["x", "z"]}, index=[0, 2])
     result = filter_df_by_column_values(df, "A", [1, 3])
@@ -13,7 +16,19 @@ def test_filter_df_by_column_values() -> None:
 
 
 def test_filter_df_by_column_values_missing() -> None:
-    """Filtering on a non-existent column should raise ``KeyError``."""
+    """
+    Filtering on a non-existent column should raise ``KeyError``.
+    """
+    # Test case 2: Missing column
     df = pd.DataFrame({"A": [1]})
     with pytest.raises(KeyError):
         filter_df_by_column_values(df, "B", [1])
+
+
+def test_filter_df_by_column_values_invalid_df() -> None:
+    """
+    Ensure passing a non-DataFrame raises ``AttributeError``.
+    """
+    # Test case 3: Invalid DataFrame input
+    with pytest.raises(AttributeError):
+        filter_df_by_column_values("not a df", "A", [1])

--- a/pytest/unit/pandas_functions/test_group_df_by_columns.py
+++ b/pytest/unit/pandas_functions/test_group_df_by_columns.py
@@ -4,14 +4,31 @@ import pytest
 from pandas_functions import group_df_by_columns
 
 
-def test_group_df_by_columns():
+def test_group_df_by_columns() -> None:
+    """
+    Grouping by a column and aggregating should compute expected values.
+    """
+    # Test case 1: Group and aggregate
     df = pd.DataFrame({"A": ["x", "x", "y"], "B": [1, 2, 3], "C": [4, 5, 6]})
     expected = pd.DataFrame({"A": ["x", "y"], "B": [1.5, 3.0], "C": [9, 6]})
     result = group_df_by_columns(df, "A", {"B": "mean", "C": "sum"})
     pd.testing.assert_frame_equal(result, expected)
 
 
-def test_group_df_by_columns_missing_column():
+def test_group_df_by_columns_missing_column() -> None:
+    """
+    Grouping by a missing column should raise ``KeyError``.
+    """
+    # Test case 2: Missing column
     df = pd.DataFrame({"A": [1, 2], "B": [3, 4]})
     with pytest.raises(KeyError):
         group_df_by_columns(df, "C", {"B": "sum"})
+
+
+def test_group_df_by_columns_invalid_df() -> None:
+    """
+    Ensure passing a non-DataFrame raises ``AttributeError``.
+    """
+    # Test case 3: Invalid DataFrame input
+    with pytest.raises(AttributeError):
+        group_df_by_columns("not a df", "A", {"B": "sum"})

--- a/pytest/unit/pandas_functions/test_melt_df.py
+++ b/pytest/unit/pandas_functions/test_melt_df.py
@@ -4,7 +4,11 @@ import pytest
 from pandas_functions import melt_df
 
 
-def test_melt_df():
+def test_melt_df() -> None:
+    """
+    Melting a DataFrame should convert columns into rows.
+    """
+    # Test case 1: Melt DataFrame with id and value vars
     df = pd.DataFrame({"A": [1, 2], "B": [3, 4], "C": [5, 6]})
     expected = pd.DataFrame(
         {"A": [1, 2, 1, 2], "variable": ["B", "B", "C", "C"], "value": [3, 4, 5, 6]}
@@ -13,7 +17,20 @@ def test_melt_df():
     pd.testing.assert_frame_equal(result, expected)
 
 
-def test_melt_df_missing_column():
+def test_melt_df_missing_column() -> None:
+    """
+    Passing missing ``value_vars`` should raise ``KeyError``.
+    """
+    # Test case 2: Missing value column
     df = pd.DataFrame({"A": [1, 2], "B": [3, 4]})
     with pytest.raises(KeyError):
         melt_df(df, id_vars="A", value_vars=["B", "C"])
+
+
+def test_melt_df_invalid_df() -> None:
+    """
+    Ensure passing a non-DataFrame raises ``AttributeError``.
+    """
+    # Test case 3: Invalid DataFrame input
+    with pytest.raises(AttributeError):
+        melt_df("not a df", id_vars="A", value_vars=["B"])

--- a/pytest/unit/pandas_functions/test_merge_dataframes.py
+++ b/pytest/unit/pandas_functions/test_merge_dataframes.py
@@ -6,8 +6,11 @@ from pandas.testing import assert_frame_equal
 from pandas_functions.merge_dataframes import merge_dataframes
 
 
-def test_merge_dataframes_inner():
-    """Verify inner merge returns intersection of keys."""
+def test_merge_dataframes_inner() -> None:
+    """
+    Verify inner merge returns intersection of keys.
+    """
+    # Test case 1: Inner merge on common key
     df1 = pd.DataFrame({"id": [1, 2], "value1": ["a", "b"]})
     df2 = pd.DataFrame({"id": [2, 3], "value2": ["x", "y"]})
     expected = pd.DataFrame({"id": [2], "value1": ["b"], "value2": ["x"]})
@@ -16,8 +19,11 @@ def test_merge_dataframes_inner():
     assert_frame_equal(result, expected)
 
 
-def test_merge_dataframes_outer():
-    """Verify outer merge includes all keys from both DataFrames."""
+def test_merge_dataframes_outer() -> None:
+    """
+    Verify outer merge includes all keys from both DataFrames.
+    """
+    # Test case 2: Outer merge
     df1 = pd.DataFrame({"id": [1, 2], "value1": ["a", "b"]})
     df2 = pd.DataFrame({"id": [2, 3], "value2": ["x", "y"]})
     expected = pd.DataFrame(
@@ -33,9 +39,21 @@ def test_merge_dataframes_outer():
 
 
 def test_merge_dataframes_missing_on() -> None:
-    """Missing join column should raise KeyError."""
+    """
+    Missing join column should raise ``KeyError``.
+    """
+    # Test case 3: Missing join column
     df1 = pd.DataFrame({"id": [1]})
     df2 = pd.DataFrame({"other": [1]})
     with pytest.raises(KeyError):
         merge_dataframes(df1, df2, on="id")
+
+
+def test_merge_dataframes_invalid_df() -> None:
+    """
+    Ensure passing a non-DataFrame raises ``AttributeError``.
+    """
+    # Test case 4: Invalid DataFrame input
+    with pytest.raises(AttributeError):
+        merge_dataframes("not a df", pd.DataFrame({"id": [1]}), on="id")
 

--- a/pytest/unit/pandas_functions/test_pivot_df.py
+++ b/pytest/unit/pandas_functions/test_pivot_df.py
@@ -4,17 +4,32 @@ import pytest
 from pandas_functions import pivot_df
 
 
-def test_pivot_df():
+def test_pivot_df() -> None:
+    """
+    Pivoting a DataFrame should reorganize data correctly.
+    """
+    # Test case 1: Pivot with aggregation and fill value
     df = pd.DataFrame({"A": [1, 1, 2], "B": ["x", "y", "x"], "C": [10, 20, 30]})
-    expected = pd.DataFrame(
-        {"x": [10, 30], "y": [20, 0]}, index=pd.Index([1, 2], name="A")
-    )
+    expected = pd.DataFrame({"x": [10, 30], "y": [20, 0]}, index=pd.Index([1, 2], name="A"))
     expected.columns.name = "B"
     result = pivot_df(df, index="A", columns="B", values="C", aggfunc="sum", fill_value=0)
     pd.testing.assert_frame_equal(result, expected)
 
 
-def test_pivot_df_missing_column():
+def test_pivot_df_missing_column() -> None:
+    """
+    Passing a missing column should raise ``KeyError``.
+    """
+    # Test case 2: Missing values column
     df = pd.DataFrame({"A": [1, 2], "B": [3, 4]})
     with pytest.raises(KeyError):
         pivot_df(df, index="A", columns="B", values="C")
+
+
+def test_pivot_df_invalid_df() -> None:
+    """
+    Ensure passing a non-DataFrame raises ``AttributeError``.
+    """
+    # Test case 3: Invalid DataFrame input
+    with pytest.raises(AttributeError):
+        pivot_df("not a df", index="A", columns="B", values="C")

--- a/pytest/unit/pandas_functions/test_rename_df_columns.py
+++ b/pytest/unit/pandas_functions/test_rename_df_columns.py
@@ -1,11 +1,15 @@
 import pandas as pd
+import pandas as pd
 import pytest
 
 from pandas_functions.rename_df_columns import rename_df_columns
 
 
 def test_rename_df_columns() -> None:
-    """Renaming columns should apply the provided mapping."""
+    """
+    Renaming columns should apply the provided mapping.
+    """
+    # Test case 1: Rename existing column
     df = pd.DataFrame({"A": [1, 2], "B": [3, 4]})
     expected = pd.DataFrame({"X": [1, 2], "B": [3, 4]})
     result = rename_df_columns(df, {"A": "X"})
@@ -13,7 +17,19 @@ def test_rename_df_columns() -> None:
 
 
 def test_rename_df_columns_missing() -> None:
-    """Renaming a non-existent column should raise ``KeyError``."""
+    """
+    Renaming a non-existent column should raise ``KeyError``.
+    """
+    # Test case 2: Missing column
     df = pd.DataFrame({"A": [1, 2]})
     with pytest.raises(KeyError):
         rename_df_columns(df, {"B": "X"})
+
+
+def test_rename_df_columns_invalid_df() -> None:
+    """
+    Ensure passing a non-DataFrame raises ``AttributeError``.
+    """
+    # Test case 3: Invalid DataFrame input
+    with pytest.raises(AttributeError):
+        rename_df_columns("not a df", {"A": "X"})

--- a/pytest/unit/pandas_functions/test_rename_df_index.py
+++ b/pytest/unit/pandas_functions/test_rename_df_index.py
@@ -1,11 +1,15 @@
 import pandas as pd
+import pandas as pd
 import pytest
 
 from pandas_functions.rename_df_index import rename_df_index
 
 
 def test_rename_df_index() -> None:
-    """Mapping should rename index labels."""
+    """
+    Mapping should rename index labels.
+    """
+    # Test case 1: Rename existing index label
     df = pd.DataFrame({"A": [1]}, index=["old"])
     expected = pd.DataFrame({"A": [1]}, index=["new"])
     result = rename_df_index(df, {"old": "new"})
@@ -13,7 +17,19 @@ def test_rename_df_index() -> None:
 
 
 def test_rename_df_index_missing_label() -> None:
-    """Missing labels should raise KeyError."""
+    """
+    Missing labels should raise ``KeyError``.
+    """
+    # Test case 2: Missing index label
     df = pd.DataFrame({"A": [1]}, index=["old"])
     with pytest.raises(KeyError):
         rename_df_index(df, {"missing": "new"})
+
+
+def test_rename_df_index_invalid_df() -> None:
+    """
+    Ensure passing a non-DataFrame raises ``AttributeError``.
+    """
+    # Test case 3: Invalid DataFrame input
+    with pytest.raises(AttributeError):
+        rename_df_index("not a df", {"old": "new"})

--- a/pytest/unit/pandas_functions/test_replace_df_column_values.py
+++ b/pytest/unit/pandas_functions/test_replace_df_column_values.py
@@ -1,11 +1,15 @@
 import pandas as pd
+import pandas as pd
 import pytest
 
 from pandas_functions.replace_df_column_values import replace_df_column_values
 
 
 def test_replace_df_column_values() -> None:
-    """Values in a column should be replaced using the mapping."""
+    """
+    Values in a column should be replaced using the mapping.
+    """
+    # Test case 1: Replace values using mapping
     df = pd.DataFrame({"A": [1, 2, 1]})
     expected = pd.DataFrame({"A": ["one", "two", "one"]})
     result = replace_df_column_values(df, "A", {1: "one", 2: "two"})
@@ -13,7 +17,19 @@ def test_replace_df_column_values() -> None:
 
 
 def test_replace_df_column_values_missing_column() -> None:
-    """Replacing a non-existent column should raise ``KeyError``."""
+    """
+    Replacing a non-existent column should raise ``KeyError``.
+    """
+    # Test case 2: Missing column
     df = pd.DataFrame({"A": [1]})
     with pytest.raises(KeyError):
         replace_df_column_values(df, "B", {1: "one"})
+
+
+def test_replace_df_column_values_invalid_df() -> None:
+    """
+    Ensure passing a non-DataFrame raises ``AttributeError``.
+    """
+    # Test case 3: Invalid DataFrame input
+    with pytest.raises(AttributeError):
+        replace_df_column_values("not a df", "A", {1: "one"})

--- a/pytest/unit/pandas_functions/test_reset_df_index.py
+++ b/pytest/unit/pandas_functions/test_reset_df_index.py
@@ -1,10 +1,14 @@
 import pandas as pd
+import pytest
 
 from pandas_functions.reset_df_index import reset_df_index
 
 
 def test_reset_df_index() -> None:
-    """Resetting the index should move it to a column by default."""
+    """
+    Resetting the index should move it to a column by default.
+    """
+    # Test case 1: Reset index with column insertion
     df = pd.DataFrame({"A": [1, 2]}, index=["x", "y"])
     result = reset_df_index(df)
     expected = pd.DataFrame({"index": ["x", "y"], "A": [1, 2]})
@@ -12,8 +16,20 @@ def test_reset_df_index() -> None:
 
 
 def test_reset_df_index_drop() -> None:
-    """Dropping the index should remove it from the DataFrame."""
+    """
+    Dropping the index should remove it from the DataFrame.
+    """
+    # Test case 2: Reset index with drop
     df = pd.DataFrame({"A": [1, 2]}, index=[10, 11])
     result = reset_df_index(df, drop=True)
     expected = pd.DataFrame({"A": [1, 2]})
     pd.testing.assert_frame_equal(result, expected)
+
+
+def test_reset_df_index_invalid_df() -> None:
+    """
+    Ensure passing a non-DataFrame raises ``AttributeError``.
+    """
+    # Test case 3: Invalid DataFrame input
+    with pytest.raises(AttributeError):
+        reset_df_index("not a df")

--- a/pytest/unit/pandas_functions/test_select_df_columns.py
+++ b/pytest/unit/pandas_functions/test_select_df_columns.py
@@ -1,11 +1,15 @@
 import pandas as pd
+import pandas as pd
 import pytest
 
 from pandas_functions.select_df_columns import select_df_columns
 
 
 def test_select_df_columns() -> None:
-    """Selecting specific columns should return them in order."""
+    """
+    Selecting specific columns should return them in order.
+    """
+    # Test case 1: Select columns by order
     df = pd.DataFrame({"A": [1, 2], "B": [3, 4], "C": [5, 6]})
     expected = pd.DataFrame({"B": [3, 4], "A": [1, 2]})
     result = select_df_columns(df, ["B", "A"])
@@ -13,8 +17,20 @@ def test_select_df_columns() -> None:
 
 
 def test_select_df_columns_missing() -> None:
-    """Requesting a non-existent column should raise ``KeyError``."""
+    """
+    Requesting a non-existent column should raise ``KeyError``.
+    """
+    # Test case 2: Missing column
     df = pd.DataFrame({"A": [1, 2]})
     with pytest.raises(KeyError):
         select_df_columns(df, ["B"])
+
+
+def test_select_df_columns_invalid_df() -> None:
+    """
+    Ensure passing a non-DataFrame raises ``AttributeError``.
+    """
+    # Test case 3: Invalid DataFrame input
+    with pytest.raises(AttributeError):
+        select_df_columns("not a df", ["A"])
 

--- a/pytest/unit/pandas_functions/test_set_df_index.py
+++ b/pytest/unit/pandas_functions/test_set_df_index.py
@@ -5,7 +5,10 @@ from pandas_functions.set_df_index import set_df_index
 
 
 def test_set_df_index() -> None:
-    """Setting a column as index should remove it by default."""
+    """
+    Setting a column as index should remove it by default.
+    """
+    # Test case 1: Set column as index with drop
     df = pd.DataFrame({"A": [1, 2], "B": ["x", "y"]})
     result = set_df_index(df, ["B"])
     expected = pd.DataFrame({"A": [1, 2]}, index=pd.Index(["x", "y"], name="B"))
@@ -13,7 +16,10 @@ def test_set_df_index() -> None:
 
 
 def test_set_df_index_drop_false() -> None:
-    """Setting the index with ``drop=False`` should retain the column."""
+    """
+    Setting the index with ``drop=False`` should retain the column.
+    """
+    # Test case 2: Set index without dropping column
     df = pd.DataFrame({"A": [1, 2], "B": ["x", "y"]})
     result = set_df_index(df, ["B"], drop=False)
     expected = pd.DataFrame({"A": [1, 2], "B": ["x", "y"]}).set_index("B", drop=False)
@@ -21,7 +27,19 @@ def test_set_df_index_drop_false() -> None:
 
 
 def test_set_df_index_missing() -> None:
-    """Setting a non-existent column as index should raise ``KeyError``."""
+    """
+    Setting a non-existent column as index should raise ``KeyError``.
+    """
+    # Test case 3: Missing column
     df = pd.DataFrame({"A": [1, 2]})
     with pytest.raises(KeyError):
         set_df_index(df, ["B"])
+
+
+def test_set_df_index_invalid_df() -> None:
+    """
+    Ensure passing a non-DataFrame raises ``AttributeError``.
+    """
+    # Test case 4: Invalid DataFrame input
+    with pytest.raises(AttributeError):
+        set_df_index("not a df", ["A"])

--- a/pytest/unit/pandas_functions/test_shuffle_df_rows.py
+++ b/pytest/unit/pandas_functions/test_shuffle_df_rows.py
@@ -1,11 +1,24 @@
 import pandas as pd
+import pytest
 
 from pandas_functions.shuffle_df_rows import shuffle_df_rows
 
 
 def test_shuffle_df_rows() -> None:
-    """Shuffling rows should change their order deterministically with a seed."""
+    """
+    Shuffling rows should change their order deterministically with a seed.
+    """
+    # Test case 1: Shuffle rows with random_state
     df = pd.DataFrame({"A": [1, 2, 3]})
     expected = pd.DataFrame({"A": [1, 3, 2]})
     result = shuffle_df_rows(df, random_state=1)
     pd.testing.assert_frame_equal(result, expected)
+
+
+def test_shuffle_df_rows_invalid_df() -> None:
+    """
+    Ensure passing a non-DataFrame raises ``AttributeError``.
+    """
+    # Test case 2: Invalid DataFrame input
+    with pytest.raises(AttributeError):
+        shuffle_df_rows("not a df")

--- a/pytest/unit/pandas_functions/test_sort_df_by_columns.py
+++ b/pytest/unit/pandas_functions/test_sort_df_by_columns.py
@@ -1,4 +1,5 @@
 import pandas as pd
+import pandas as pd
 import pytest
 from pandas.testing import assert_frame_equal
 
@@ -6,7 +7,10 @@ from pandas_functions.sort_df_by_columns import sort_df_by_columns
 
 
 def test_sort_df_by_single_column() -> None:
-    """Sorting by a single column should order values ascending."""
+    """
+    Sorting by a single column should order values ascending.
+    """
+    # Test case 1: Sort by one column
     df = pd.DataFrame({"A": [3, 1, 2]})
     expected = pd.DataFrame({"A": [1, 2, 3]})
     result = sort_df_by_columns(df, "A")
@@ -14,7 +18,10 @@ def test_sort_df_by_single_column() -> None:
 
 
 def test_sort_df_by_multiple_columns_descending() -> None:
-    """Sorting by multiple columns with mixed order should work."""
+    """
+    Sorting by multiple columns with mixed order should work.
+    """
+    # Test case 2: Sort by multiple columns
     df = pd.DataFrame({"A": [1, 2, 1], "B": [2, 1, 1]})
     expected = pd.DataFrame({"A": [1, 1, 2], "B": [2, 1, 1]})
     result = sort_df_by_columns(df, ["A", "B"], ascending=[True, False])
@@ -22,8 +29,20 @@ def test_sort_df_by_multiple_columns_descending() -> None:
 
 
 def test_sort_df_by_columns_missing() -> None:
-    """Sorting by a non-existent column should raise ``KeyError``."""
+    """
+    Sorting by a non-existent column should raise ``KeyError``.
+    """
+    # Test case 3: Missing column
     df = pd.DataFrame({"A": [1, 2]})
     with pytest.raises(KeyError):
         sort_df_by_columns(df, "B")
+
+
+def test_sort_df_by_columns_invalid_df() -> None:
+    """
+    Ensure passing a non-DataFrame raises ``AttributeError``.
+    """
+    # Test case 4: Invalid DataFrame input
+    with pytest.raises(AttributeError):
+        sort_df_by_columns("not a df", "A")
 

--- a/pytest/unit/pandas_functions/test_sort_df_by_index.py
+++ b/pytest/unit/pandas_functions/test_sort_df_by_index.py
@@ -1,15 +1,29 @@
 import pandas as pd
+import pytest
 
 from pandas_functions.sort_df_by_index import sort_df_by_index
 
 
 def test_sort_df_by_index() -> None:
-    """Sorting by index should reorder rows accordingly."""
+    """
+    Sorting by index should reorder rows accordingly.
+    """
+    # Test case 1: Sort ascending
     df = pd.DataFrame({"A": [1, 2]}, index=[2, 1])
     expected_asc = pd.DataFrame({"A": [2, 1]}, index=[1, 2])
     result_asc = sort_df_by_index(df)
     pd.testing.assert_frame_equal(result_asc, expected_asc)
 
+    # Test case 2: Sort descending
     expected_desc = pd.DataFrame({"A": [1, 2]}, index=[2, 1])
     result_desc = sort_df_by_index(df, ascending=False)
     pd.testing.assert_frame_equal(result_desc, expected_desc)
+
+
+def test_sort_df_by_index_invalid_df() -> None:
+    """
+    Ensure passing a non-DataFrame raises ``AttributeError``.
+    """
+    # Test case 3: Invalid DataFrame input
+    with pytest.raises(AttributeError):
+        sort_df_by_index("not a df")

--- a/pytest/unit/pandas_functions/test_sort_df_columns.py
+++ b/pytest/unit/pandas_functions/test_sort_df_columns.py
@@ -1,10 +1,14 @@
 import pandas as pd
+import pytest
 
 from pandas_functions.sort_df_columns import sort_df_columns
 
 
 def test_sort_df_columns_ascending() -> None:
-    """Columns should be sorted alphabetically."""
+    """
+    Columns should be sorted alphabetically.
+    """
+    # Test case 1: Sort columns ascending
     df = pd.DataFrame({"B": [1], "A": [2]})
     result = sort_df_columns(df)
     expected = pd.DataFrame({"A": [2], "B": [1]})
@@ -12,8 +16,20 @@ def test_sort_df_columns_ascending() -> None:
 
 
 def test_sort_df_columns_descending() -> None:
-    """Descending order should reverse column order."""
+    """
+    Descending order should reverse column order.
+    """
+    # Test case 2: Sort columns descending
     df = pd.DataFrame({"B": [1], "A": [2]})
     result = sort_df_columns(df, ascending=False)
     expected = pd.DataFrame({"B": [1], "A": [2]})
     pd.testing.assert_frame_equal(result, expected)
+
+
+def test_sort_df_columns_invalid_df() -> None:
+    """
+    Ensure passing a non-DataFrame raises ``AttributeError``.
+    """
+    # Test case 3: Invalid DataFrame input
+    with pytest.raises(AttributeError):
+        sort_df_columns("not a df")

--- a/pytest/unit/pandas_functions/test_split_df_column.py
+++ b/pytest/unit/pandas_functions/test_split_df_column.py
@@ -5,6 +5,10 @@ from pandas_functions.split_df_column import split_df_column
 
 
 def test_split_df_column_basic() -> None:
+    """
+    Splitting a column into multiple columns should distribute values.
+    """
+    # Test case 1: Basic split by space
     df = pd.DataFrame({"name": ["John Doe", "Jane Smith"], "age": [30, 25]})
     result = split_df_column(df, "name", ["first", "last"], " ")
     expected = pd.DataFrame({"age": [30, 25], "first": ["John", "Jane"], "last": ["Doe", "Smith"]})
@@ -12,12 +16,29 @@ def test_split_df_column_basic() -> None:
 
 
 def test_split_df_column_missing_column() -> None:
+    """
+    Splitting a non-existent column should raise ``KeyError``.
+    """
+    # Test case 2: Missing column
     df = pd.DataFrame({"name": ["John Doe"]})
     with pytest.raises(KeyError):
         split_df_column(df, "missing", ["first", "last"], " ")
 
 
 def test_split_df_column_mismatch_into() -> None:
+    """
+    Providing mismatched target columns should raise ``ValueError``.
+    """
+    # Test case 3: Mismatched target columns
     df = pd.DataFrame({"name": ["John Doe"], "age": [30]})
     with pytest.raises(ValueError):
         split_df_column(df, "name", ["first", "middle", "last"], " ")
+
+
+def test_split_df_column_invalid_df() -> None:
+    """
+    Ensure passing a non-DataFrame raises ``AttributeError``.
+    """
+    # Test case 4: Invalid DataFrame input
+    with pytest.raises(AttributeError):
+        split_df_column("not a df", "name", ["first", "last"], " ")


### PR DESCRIPTION
## Summary
- standardize pandas function tests with docstrings, case comments, and type hints
- add error scenario coverage across pandas utility tests

## Testing
- `pytest`
- `pytest pytest/unit/pandas_functions/test_split_df_column.py`


------
https://chatgpt.com/codex/tasks/task_e_68a76a84fc508325a9fdae16d48b6cba