### PR TITLE
Add array sum and elementwise power utilities

### DIFF
--- a/numpy_functions/__init__.py
+++ b/numpy_functions/__init__.py
@@ -4,11 +4,13 @@ from .array_std import array_std
 from .array_median import array_median
 from .array_max import array_max
 from .array_min import array_min
+from .array_sum import array_sum
 from .dot_product import dot_product
 from .elementwise_sum import elementwise_sum
 from .elementwise_product import elementwise_product
 from .elementwise_divide import elementwise_divide
 from .elementwise_subtract import elementwise_subtract
+from .elementwise_power import elementwise_power
 from .matrix_multiply import matrix_multiply
 from .normalize_array import normalize_array
 
@@ -19,11 +21,13 @@ __all__ = [
     "array_median",
     "array_max",
     "array_min",
+    "array_sum",
     "dot_product",
     "elementwise_sum",
     "elementwise_product",
     "elementwise_divide",
     "elementwise_subtract",
+    "elementwise_power",
     "matrix_multiply",
     "normalize_array",
 ]

--- a/numpy_functions/array_sum.py
+++ b/numpy_functions/array_sum.py
@@ -1,0 +1,33 @@
+import numpy as np
+
+
+def array_sum(arr: np.ndarray) -> float:
+    """
+    Compute the sum of all elements in a NumPy array.
+
+    Parameters
+    ----------
+    arr : np.ndarray
+        Array containing numerical values.
+
+    Returns
+    -------
+    float
+        The sum of all elements in the array.
+
+    Raises
+    ------
+    TypeError
+        If `arr` is not a NumPy ndarray.
+
+    Examples
+    --------
+    >>> array_sum(np.array([1, 2, 3]))
+    6.0
+    """
+    if not isinstance(arr, np.ndarray):
+        raise TypeError("arr must be a numpy.ndarray.")
+    return float(np.sum(arr))
+
+
+__all__ = ["array_sum"]

--- a/numpy_functions/elementwise_power.py
+++ b/numpy_functions/elementwise_power.py
@@ -1,0 +1,39 @@
+import numpy as np
+
+
+def elementwise_power(arr1: np.ndarray, arr2: np.ndarray) -> np.ndarray:
+    """
+    Raise elements of one array to the powers of the corresponding elements of another array.
+
+    Parameters
+    ----------
+    arr1 : np.ndarray
+        The base array.
+    arr2 : np.ndarray
+        The exponent array.
+
+    Returns
+    -------
+    np.ndarray
+        Array where each element is ``arr1`` raised to the power of the corresponding element in ``arr2``.
+
+    Raises
+    ------
+    TypeError
+        If either input is not a NumPy ndarray.
+    ValueError
+        If the arrays do not have the same shape.
+
+    Examples
+    --------
+    >>> elementwise_power(np.array([2, 3]), np.array([3, 2]))
+    array([8, 9])
+    """
+    if not isinstance(arr1, np.ndarray) or not isinstance(arr2, np.ndarray):
+        raise TypeError("Both inputs must be numpy.ndarray.")
+    if arr1.shape != arr2.shape:
+        raise ValueError("Arrays must have the same shape.")
+    return np.power(arr1, arr2)
+
+
+__all__ = ["elementwise_power"]

--- a/pytest/unit/numpy_functions/test_array_sum.py
+++ b/pytest/unit/numpy_functions/test_array_sum.py
@@ -1,0 +1,28 @@
+import numpy as np
+import pytest
+from numpy_functions.array_sum import array_sum
+
+
+
+def test_array_sum_basic() -> None:
+    """
+    Test the array_sum function with positive integers.
+    """
+    assert array_sum(np.array([1, 2, 3])) == 6.0, "Failed on positive integers"
+
+
+
+def test_array_sum_negative() -> None:
+    """
+    Test the array_sum function with negative numbers.
+    """
+    assert array_sum(np.array([-1, -2, -3])) == -6.0, "Failed on negative numbers"
+
+
+
+def test_array_sum_invalid_type() -> None:
+    """
+    Test the array_sum function with an invalid input type.
+    """
+    with pytest.raises(TypeError):
+        array_sum([1, 2, 3])

--- a/pytest/unit/numpy_functions/test_elementwise_power.py
+++ b/pytest/unit/numpy_functions/test_elementwise_power.py
@@ -1,0 +1,31 @@
+import numpy as np
+import pytest
+from numpy_functions.elementwise_power import elementwise_power
+
+
+
+def test_elementwise_power_basic() -> None:
+    """
+    Test elementwise_power with arrays of the same shape.
+    """
+    result = elementwise_power(np.array([2, 3]), np.array([3, 2]))
+    expected = np.array([8, 9])
+    assert np.array_equal(result, expected), "Failed on basic element-wise power"
+
+
+
+def test_elementwise_power_mismatched_shapes() -> None:
+    """
+    Test elementwise_power with arrays of different shapes.
+    """
+    with pytest.raises(ValueError):
+        elementwise_power(np.array([1, 2]), np.array([1]))
+
+
+
+def test_elementwise_power_invalid_type() -> None:
+    """
+    Test elementwise_power with invalid input types.
+    """
+    with pytest.raises(TypeError):
+        elementwise_power([1, 2], np.array([1, 2]))


### PR DESCRIPTION
## Summary
- add `array_sum` to compute sum of array elements
- add `elementwise_power` for element-wise exponentiation of arrays
- include comprehensive unit tests

## Testing
- `pytest pytest/unit/numpy_functions -q`

------
https://chatgpt.com/codex/tasks/task_e_68a88ecacbfc832587362acaf2ccb870