### PR TITLE
refactor: add TypeVars to identify dict value lookup

### DIFF
--- a/iterable_functions/identify_value_in_dict_get_key.py
+++ b/iterable_functions/identify_value_in_dict_get_key.py
@@ -1,22 +1,25 @@
-from typing import Any
+from typing import TypeVar
+
+
+KT = TypeVar("KT", str, int)
+VT = TypeVar("VT")
 
 
 def identify_value_in_dict_get_key(
-    target_value: Any, dictionary: dict[str | int, Any]
-) -> str | int | None:
-    """
-    Identify the key in the dictionary where the target value is present.
+    target_value: VT, dictionary: dict[KT, VT]
+) -> KT | None:
+    """Identify the key in the dictionary where the target value is present.
 
     Parameters
     ----------
-    target_value : any
+    target_value : VT
         The value to find.
-    dictionary : dict
+    dictionary : dict[KT, VT]
         The dictionary where to find the value.
 
     Returns
     -------
-    str or int or None
+    KT or None
         The key of the entry where the value is present, or None if not found.
 
     Raises


### PR DESCRIPTION
## Summary
- introduce KT and VT type variables for `identify_value_in_dict_get_key`
- update function signature and docstring to use generics

## Testing
- `pytest -q` *(fails: TypeError in decorators/test_requires_permission.py::test_requires_permission_success)*
- `pytest pytest/unit/iterable_functions/test_identify_value_in_dict_get_key.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68aaedaa3c8083259600594c8f16620a