### PR TITLE
Make try_convert_to_type generic

### DIFF
--- a/iterable_functions/try_convert_to_type.py
+++ b/iterable_functions/try_convert_to_type.py
@@ -1,26 +1,29 @@
-from typing import Any
+from typing import Any, TypeVar
 
 
-def try_convert_to_type(value: Any, target_type: type) -> Any:
+T = TypeVar("T")
+
+
+def try_convert_to_type(value: Any, target_type: type[T]) -> T:
     """
-    Attempts to convert a given value to a specified type.
+    Attempt to convert ``value`` to ``target_type``.
 
     Parameters
     ----------
     value : Any
         The value to be converted.
-    target_type : Type
-        The type to which `value` should be converted.
+    target_type : type[T]
+        The type to which ``value`` should be converted.
 
     Returns
     -------
-    Any
+    T
         The converted value if the conversion is successful.
 
     Raises
     ------
     TypeError
-        If target_type is not a type.
+        If ``target_type`` is not a ``type``.
     ValueError
         If the conversion fails.
     """


### PR DESCRIPTION
## Summary
- make `try_convert_to_type` generic using `TypeVar`
- update docstring to describe generic target type and return value

## Testing
- `pytest` *(fails: pytest/unit/decorators/test_requires_permission.py::test_requires_permission_success - TypeError: sample_function() takes 0 positional arguments but 1 was given)*
- `mypy iterable_functions/try_convert_to_type.py` *(fails: python-utils is not a valid Python package name)*

------
https://chatgpt.com/codex/tasks/task_e_68aaeda9b1448325a1ebd13692b8e356