### PR TITLE
docs: standardize docstrings across modules

### DIFF
--- a/compression_functions/binary_compression/compress_gzip.py
+++ b/compression_functions/binary_compression/compress_gzip.py
@@ -22,6 +22,12 @@ def compress_gzip(data: bytes) -> bytes:
         If data is not bytes.
     ValueError
         If an error occurs during compression.
+
+    Examples
+    --------
+    >>> compressed = compress_gzip(b"data")
+    >>> len(compressed) > 0
+    True
     """
     # Check if data is bytes
     if not isinstance(data, bytes):

--- a/compression_functions/binary_compression/decompress_gzip.py
+++ b/compression_functions/binary_compression/decompress_gzip.py
@@ -22,6 +22,13 @@ def decompress_gzip(compressed_data: bytes) -> bytes:
         If compressed_data is not bytes.
     ValueError
         If an error occurs during decompression.
+
+    Examples
+    --------
+    >>> from .compress_gzip import compress_gzip
+    >>> compressed = compress_gzip(b"data")
+    >>> decompress_gzip(compressed)
+    b"data"
     """
     # Check if compressed_data is bytes
     if not isinstance(compressed_data, bytes):

--- a/compression_functions/files_compression/compress_file_bz2.py
+++ b/compression_functions/files_compression/compress_file_bz2.py
@@ -13,6 +13,11 @@ def compress_file_bz2(input_file: str, output_file: str) -> None:
     output_file : str
         The path to the output file to save the compressed data.
 
+    Returns
+    -------
+    None
+        This function does not return anything.
+
     Raises
     ------
     TypeError
@@ -21,6 +26,12 @@ def compress_file_bz2(input_file: str, output_file: str) -> None:
         If the input file does not exist.
     IOError
         If an I/O error occurs during compression.
+
+    Examples
+    --------
+    >>> compress_file_bz2('input.txt', 'output.bz2')  # doctest: +SKIP
+    >>> os.path.exists('output.bz2')  # doctest: +SKIP
+    True
     """
     # Check if input_file and output_file are strings
     if not isinstance(input_file, str):
@@ -41,12 +52,17 @@ def compress_file_bz2(input_file: str, output_file: str) -> None:
         # Explicitly verify write permissions on the output directory or file.
         if os.stat(output_dir).st_mode & 0o222 == 0:
             raise OSError("Output location is not writable")
-        if os.path.exists(output_file) and os.stat(output_file).st_mode & 0o222 == 0:
+        if (
+            os.path.exists(output_file)
+            and os.stat(output_file).st_mode & 0o222 == 0
+        ):
             raise OSError("Output file is not writable")
 
         # Open the input file in binary read mode and write the compressed
         # contents to the output file.
-        with open(input_file, "rb") as f_in, bz2.open(output_file, "wb") as f_out:
+        with open(input_file, "rb") as f_in, bz2.open(
+            output_file, "wb"
+        ) as f_out:
             f_out.writelines(f_in)
     except FileNotFoundError:
         # Re-raise file not found errors for callers to handle.

--- a/datetime_functions/modify_years.py
+++ b/datetime_functions/modify_years.py
@@ -4,30 +4,52 @@ from datetime import datetime, date
 from typing import Union
 
 
-def modify_years(date_obj: Union[datetime, date], years: int) -> Union[datetime, date]:
+def modify_years(
+    date_obj: Union[datetime, date], years: int
+) -> Union[datetime, date]:
     """
-    Add or subtract a specified number of years from a datetime or date object.
-    
-    Args:
-        date_obj: The datetime or date object to modify
-        years: Number of years to add (positive) or subtract (negative)
-        
-    Returns:
-        New datetime or date object with years modified
-        
-    Raises:
-        TypeError: If date_obj is not a datetime or date object
-        TypeError: If years is not an integer
-        ValueError: If the resulting date would be invalid (e.g., Feb 29 on non-leap year)
+    Add or subtract a specified number of years from a datetime or
+    date object.
+
+    Parameters
+    ----------
+    date_obj : datetime | date
+        The date or datetime to modify.
+    years : int
+        Number of years to add (positive) or subtract (negative).
+
+    Returns
+    -------
+    datetime | date
+        The modified date or datetime.
+
+    Raises
+    ------
+    TypeError
+        If ``date_obj`` is not a :class:`datetime.datetime` or
+        :class:`datetime.date`.
+    TypeError
+        If ``years`` is not an integer.
+    ValueError
+        If the resulting date would be invalid (e.g., February 29 on a
+        non-leap year).
+
+    Examples
+    --------
+    >>> from datetime import date, datetime
+    >>> modify_years(date(2020, 2, 29), 1)
+    datetime.date(2021, 2, 28)
+    >>> modify_years(datetime(2020, 5, 17), -2)
+    datetime.datetime(2018, 5, 17, 0, 0)
     """
     if not isinstance(date_obj, (datetime, date)):
         raise TypeError("date_obj must be a datetime or date object")
-    
+
     if not isinstance(years, int):
         raise TypeError("years must be an integer")
-    
+
     new_year = date_obj.year + years
-    
+
     try:
         if isinstance(date_obj, datetime):
             return date_obj.replace(year=new_year)

--- a/decorators/cache.py
+++ b/decorators/cache.py
@@ -18,6 +18,22 @@ def cache(func: Callable[P, R]) -> Callable[P, R]:
     -------
     Callable[P, R]
         A wrapper function that caches the results of the input function.
+
+    Raises
+    ------
+    TypeError
+        If the decorated function is later called with unhashable arguments.
+
+    Examples
+    --------
+    >>> @cache
+    ... def add(a: int, b: int) -> int:
+    ...     return a + b
+    >>> add(1, 2)
+    3
+    >>> add(1, 2)  # Cached result
+    3
+    >>> add.cache_clear()
     """
 
     cached_results: dict[tuple[tuple[Any, ...],

--- a/file_functions/json_to_dict.py
+++ b/file_functions/json_to_dict.py
@@ -15,6 +15,18 @@ def json_to_dict(file_path: str) -> dict[str, Any]:
     -------
     Dict[str, Any]
         Dictionary representation of the JSON contents.
+
+    Raises
+    ------
+    FileNotFoundError
+        If ``file_path`` does not exist.
+    json.JSONDecodeError
+        If the file does not contain valid JSON.
+
+    Examples
+    --------
+    >>> json_to_dict('example.json')  # doctest: +SKIP
+    {'key': 'value'}
     """
     with open(file_path) as f:
         data: dict[str, Any] = json.load(f)


### PR DESCRIPTION
## Summary
- expand compression function docs with usage examples
- document file and datetime utilities with consistent sections
- clarify caching decorator and JSON loader behavior

## Testing
- `flake8 compression_functions/binary_compression/compress_gzip.py compression_functions/binary_compression/decompress_gzip.py compression_functions/files_compression/compress_file_bz2.py datetime_functions/modify_years.py decorators/cache.py file_functions/json_to_dict.py`
- `pytest` *(fails: ValueError in http_functions tests, AssertionError in validation tests, 57 failed, 1374 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68ab33e7743c83258f17d94e11575ff2