### PR TITLE
docs: standardize docstrings across modules

### DIFF
--- a/asyncio_functions/async_connection_pool.py
+++ b/asyncio_functions/async_connection_pool.py
@@ -28,6 +28,18 @@ class AsyncConnectionPool(Generic[C]):
         ----------
         max_connections : int
             The maximum number of connections in the pool.
+
+        Returns
+        -------
+        None
+
+        Raises
+        ------
+        None
+
+        Examples
+        --------
+        >>> pool = AsyncConnectionPool[str](max_connections=2)
         """
         self.max_connections = max_connections
         self._pool: asyncio.Queue[C] = asyncio.Queue(max_connections)
@@ -36,10 +48,25 @@ class AsyncConnectionPool(Generic[C]):
         """
         Acquire a connection from the pool.
 
+        Parameters
+        ----------
+        None
+
         Returns
         -------
         C
             A connection from the pool.
+
+        Raises
+        ------
+        None
+
+        Examples
+        --------
+        >>> pool = AsyncConnectionPool[str](1)
+        >>> await pool.add_connection('conn')  # doctest: +SKIP
+        >>> await pool.acquire()  # doctest: +SKIP
+        'conn'
         """
         # Wait until a connection is available and return it
         conn = await self._pool.get()
@@ -53,6 +80,21 @@ class AsyncConnectionPool(Generic[C]):
         ----------
         conn : C
             The connection to release back to the pool.
+
+        Returns
+        -------
+        None
+
+        Raises
+        ------
+        None
+
+        Examples
+        --------
+        >>> pool = AsyncConnectionPool[str](1)
+        >>> await pool.add_connection('conn')  # doctest: +SKIP
+        >>> conn = await pool.acquire()  # doctest: +SKIP
+        >>> await pool.release(conn)  # doctest: +SKIP
         """
         # Put the connection back into the pool
         await self._pool.put(conn)
@@ -70,6 +112,15 @@ class AsyncConnectionPool(Generic[C]):
         ------
         RuntimeError
             If the connection pool is full.
+
+        Returns
+        -------
+        None
+
+        Examples
+        --------
+        >>> pool = AsyncConnectionPool[str](1)
+        >>> await pool.add_connection('conn')  # doctest: +SKIP
         """
         # Check if the pool is not full before adding the connection
         if self._pool.qsize() < self.max_connections:
@@ -95,6 +146,19 @@ async def use_connection(
     -------
     T
         The result of the task.
+
+    Raises
+    ------
+    None
+
+    Examples
+    --------
+    >>> async def task(conn: str) -> str:
+    ...     return conn.upper()
+    >>> pool = AsyncConnectionPool[str](1)
+    >>> await pool.add_connection('db')  # doctest: +SKIP
+    >>> await use_connection(pool, task)  # doctest: +SKIP
+    'DB'
     """
     # Acquire a connection from the pool
     conn = await pool.acquire()

--- a/datetime_functions/calculate_age.py
+++ b/datetime_functions/calculate_age.py
@@ -4,20 +4,37 @@ from datetime import datetime, date
 from typing import Union
 
 
-def calculate_age(birth_date: Union[datetime, date], reference_date: Union[datetime, date] = None) -> int:
+def calculate_age(
+    birth_date: Union[datetime, date],
+    reference_date: Union[datetime, date] = None,
+) -> int:
     """
-    Calculate age in years from a birth date.
-    
-    Args:
-        birth_date: The birth date
-        reference_date: The reference date to calculate age against (default: today)
-        
-    Returns:
-        Age in years
-        
-    Raises:
-        TypeError: If birth_date is not a datetime or date object
-        ValueError: If birth_date is in the future
+    Calculate the age in years from a birth date.
+
+    Parameters
+    ----------
+    birth_date : datetime | date
+        The birth date.
+    reference_date : datetime | date, optional
+        Date against which to calculate the age. Defaults to today's date.
+
+    Returns
+    -------
+    int
+        Age in completed years.
+
+    Raises
+    ------
+    TypeError
+        If ``birth_date`` or ``reference_date`` is not a ``datetime`` or ``date`` object.
+    ValueError
+        If ``birth_date`` occurs after ``reference_date``.
+
+    Examples
+    --------
+    >>> from datetime import date
+    >>> calculate_age(date(2000, 1, 1), date(2020, 1, 1))
+    20
     """
     if not isinstance(birth_date, (datetime, date)):
         raise TypeError("birth_date must be a datetime or date object")

--- a/file_functions/join_paths.py
+++ b/file_functions/join_paths.py
@@ -9,13 +9,22 @@ def join_paths(parent_path: str, child_paths: list[str]) -> str:
     ----------
     parent_path : str
         The parent directory path.
-    child_paths : List[str]
-        A list of child paths to join with the parent path.
+    child_paths : list[str]
+        A list of child path segments to join with the parent path.
 
     Returns
     -------
     str
         The joined path.
+
+    Raises
+    ------
+    None
+
+    Examples
+    --------
+    >>> join_paths('/home/user', ['docs', 'file.txt'])
+    '/home/user/docs/file.txt'
     """
     joined_paths: str = os.path.join(parent_path, *child_paths)
     return joined_paths

--- a/print_functions/print_dependencies_info_in_terminal.py
+++ b/print_functions/print_dependencies_info_in_terminal.py
@@ -20,6 +20,15 @@ def print_dependencies_info_in_terminal(dependencies: Iterable[str]) -> None:
     Returns
     -------
     None
+
+    Raises
+    ------
+    None
+
+    Examples
+    --------
+    >>> print_dependencies_info_in_terminal(['pip'])  # doctest: +ELLIPSIS
+    ...Dependencies Information...
     """
     terminal_width = shutil.get_terminal_size().columns
     separator = "=" * terminal_width

--- a/print_functions/print_message.py
+++ b/print_functions/print_message.py
@@ -35,6 +35,17 @@ def print_message(
     -------
     None
 
+    Raises
+    ------
+    None
+
+    Examples
+    --------
+    >>> print_message('Hello World')  # doctest: +ELLIPSIS
+    [INFO] ... - Hello World
+    >>> print_message('Warning!', 'warning')  # doctest: +ELLIPSIS
+    [WARNING] ... - Warning!
+
     Notes
     -----
     Messages are logged through the provided ``logger`` or the module level


### PR DESCRIPTION
## Summary
- harmonize calculate_age docstring using parameter, return, raise, and example sections
- clarify path joining and dependency info printing docstrings with standard layout
- expand async connection pool and message printing docs to describe parameters, usage, and exceptions

## Testing
- `flake8`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab388b0aec8325a1d18ccb28b52848