### PR TITLE
Use monkeypatch to manage environment variables in load_dotenv tests

### DIFF
--- a/pytest/unit/env_config_functions/test_load_dotenv.py
+++ b/pytest/unit/env_config_functions/test_load_dotenv.py
@@ -4,7 +4,7 @@ import os
 from env_config_functions.load_dotenv import load_dotenv
 
 
-def test_load_dotenv_basic():
+def test_load_dotenv_basic(monkeypatch):
     """
     Test case 1: Basic .env file loading.
     """
@@ -12,19 +12,19 @@ def test_load_dotenv_basic():
         tf.write('FOO=bar\nBAZ=qux\n')
         tf.close()
         # Clear env vars first
-        os.environ.pop('FOO', None)
-        os.environ.pop('BAZ', None)
+        monkeypatch.delenv('FOO', raising=False)
+        monkeypatch.delenv('BAZ', raising=False)
         load_dotenv(tf.name)
         assert os.environ['FOO'] == 'bar'
         assert os.environ['BAZ'] == 'qux'
     os.remove(tf.name)
 
 
-def test_load_dotenv_override():
+def test_load_dotenv_override(monkeypatch):
     """
     Test case 2: Override existing environment variables.
     """
-    os.environ['EXISTING'] = 'old'
+    monkeypatch.setenv('EXISTING', 'old')
     with tempfile.NamedTemporaryFile('w+', delete=False, suffix='.env') as tf:
         tf.write('EXISTING=new\n')
         tf.close()
@@ -33,11 +33,11 @@ def test_load_dotenv_override():
     os.remove(tf.name)
 
 
-def test_load_dotenv_no_override():
+def test_load_dotenv_no_override(monkeypatch):
     """
     Test case 3: Don't override existing environment variables.
     """
-    os.environ['EXISTING'] = 'old'
+    monkeypatch.setenv('EXISTING', 'old')
     with tempfile.NamedTemporaryFile('w+', delete=False, suffix='.env') as tf:
         tf.write('EXISTING=new\n')
         tf.close()
@@ -46,22 +46,22 @@ def test_load_dotenv_no_override():
     os.remove(tf.name)
 
 
-def test_load_dotenv_comments():
+def test_load_dotenv_comments(monkeypatch):
     """
     Test case 4: Skip comments and empty lines.
     """
     with tempfile.NamedTemporaryFile('w+', delete=False, suffix='.env') as tf:
         tf.write('# This is a comment\nVAR1=value1\n\n# Another comment\nVAR2=value2\n')
         tf.close()
-        os.environ.pop('VAR1', None)
-        os.environ.pop('VAR2', None)
+        monkeypatch.delenv('VAR1', raising=False)
+        monkeypatch.delenv('VAR2', raising=False)
         load_dotenv(tf.name)
         assert os.environ['VAR1'] == 'value1'
         assert os.environ['VAR2'] == 'value2'
     os.remove(tf.name)
 
 
-def test_load_dotenv_nonexistent_file():
+def test_load_dotenv_nonexistent_file(monkeypatch):
     """
     Test case 5: Nonexistent file doesn't raise error.
     """


### PR DESCRIPTION
## Summary
- use pytest's `monkeypatch` fixture in `test_load_dotenv.py`
- replace direct `os.environ` access with `monkeypatch.setenv` and `monkeypatch.delenv`

## Testing
- `pytest pytest/unit/env_config_functions/test_load_dotenv.py`

------
https://chatgpt.com/codex/tasks/task_e_68acad0cf03883258de13e9b47264d07