### PR TITLE
refactor: use tmp_path in env config tests

### DIFF
--- a/pytest/unit/env_config_functions/test_load_dotenv.py
+++ b/pytest/unit/env_config_functions/test_load_dotenv.py
@@ -1,64 +1,54 @@
-import pytest
-import tempfile
 import os
 from env_config_functions.load_dotenv import load_dotenv
 
 
-def test_load_dotenv_basic():
+def test_load_dotenv_basic(tmp_path):
     """
     Test case 1: Basic .env file loading.
     """
-    with tempfile.NamedTemporaryFile('w+', delete=False, suffix='.env') as tf:
-        tf.write('FOO=bar\nBAZ=qux\n')
-        tf.close()
-        # Clear env vars first
-        os.environ.pop('FOO', None)
-        os.environ.pop('BAZ', None)
-        load_dotenv(tf.name)
-        assert os.environ['FOO'] == 'bar'
-        assert os.environ['BAZ'] == 'qux'
-    os.remove(tf.name)
+    config_file = tmp_path / "config.env"
+    config_file.write_text('FOO=bar\nBAZ=qux\n')
+    # Clear env vars first
+    os.environ.pop('FOO', None)
+    os.environ.pop('BAZ', None)
+    load_dotenv(str(config_file))
+    assert os.environ['FOO'] == 'bar'
+    assert os.environ['BAZ'] == 'qux'
 
 
-def test_load_dotenv_override():
+def test_load_dotenv_override(tmp_path):
     """
     Test case 2: Override existing environment variables.
     """
     os.environ['EXISTING'] = 'old'
-    with tempfile.NamedTemporaryFile('w+', delete=False, suffix='.env') as tf:
-        tf.write('EXISTING=new\n')
-        tf.close()
-        load_dotenv(tf.name, override=True)
-        assert os.environ['EXISTING'] == 'new'
-    os.remove(tf.name)
+    config_file = tmp_path / "config.env"
+    config_file.write_text('EXISTING=new\n')
+    load_dotenv(str(config_file), override=True)
+    assert os.environ['EXISTING'] == 'new'
 
 
-def test_load_dotenv_no_override():
+def test_load_dotenv_no_override(tmp_path):
     """
     Test case 3: Don't override existing environment variables.
     """
     os.environ['EXISTING'] = 'old'
-    with tempfile.NamedTemporaryFile('w+', delete=False, suffix='.env') as tf:
-        tf.write('EXISTING=new\n')
-        tf.close()
-        load_dotenv(tf.name, override=False)
-        assert os.environ['EXISTING'] == 'old'
-    os.remove(tf.name)
+    config_file = tmp_path / "config.env"
+    config_file.write_text('EXISTING=new\n')
+    load_dotenv(str(config_file), override=False)
+    assert os.environ['EXISTING'] == 'old'
 
 
-def test_load_dotenv_comments():
+def test_load_dotenv_comments(tmp_path):
     """
     Test case 4: Skip comments and empty lines.
     """
-    with tempfile.NamedTemporaryFile('w+', delete=False, suffix='.env') as tf:
-        tf.write('# This is a comment\nVAR1=value1\n\n# Another comment\nVAR2=value2\n')
-        tf.close()
-        os.environ.pop('VAR1', None)
-        os.environ.pop('VAR2', None)
-        load_dotenv(tf.name)
-        assert os.environ['VAR1'] == 'value1'
-        assert os.environ['VAR2'] == 'value2'
-    os.remove(tf.name)
+    config_file = tmp_path / "config.env"
+    config_file.write_text('# This is a comment\nVAR1=value1\n\n# Another comment\nVAR2=value2\n')
+    os.environ.pop('VAR1', None)
+    os.environ.pop('VAR2', None)
+    load_dotenv(str(config_file))
+    assert os.environ['VAR1'] == 'value1'
+    assert os.environ['VAR2'] == 'value2'
 
 
 def test_load_dotenv_nonexistent_file():

--- a/pytest/unit/env_config_functions/test_parse_ini_config.py
+++ b/pytest/unit/env_config_functions/test_parse_ini_config.py
@@ -1,6 +1,4 @@
 import pytest
-import tempfile
-import os
 import configparser
 from env_config_functions.parse_ini_config import parse_ini_config
 
@@ -11,31 +9,27 @@ def write_ini_file(data, path):
     with open(path, 'w') as f:
         parser.write(f)
 
-def test_parse_ini_config_basic():
+def test_parse_ini_config_basic(tmp_path):
     """
     Test case 1: Basic INI config loads as dict
     """
     data = {'section1': {'a': '1'}, 'section2': {'b': '2'}}
-    with tempfile.NamedTemporaryFile('w+', delete=False, suffix='.ini') as tf:
-        write_ini_file(data, tf.name)
-        tf.close()
-        config = parse_ini_config(tf.name)
-        assert config == data
-    os.remove(tf.name)
+    config_file = tmp_path / "config.ini"
+    write_ini_file(data, config_file)
+    config = parse_ini_config(str(config_file))
+    assert config == data
 
-def test_parse_ini_config_required_sections():
+def test_parse_ini_config_required_sections(tmp_path):
     """
     Test case 2: Missing required sections raises ValueError
     """
     data = {'section1': {'a': '1'}}
-    with tempfile.NamedTemporaryFile('w+', delete=False, suffix='.ini') as tf:
-        write_ini_file(data, tf.name)
-        tf.close()
-        with pytest.raises(ValueError, match='Missing required config sections'):
-            parse_ini_config(tf.name, required_sections=['section1', 'section2'])
-    os.remove(tf.name)
+    config_file = tmp_path / "config.ini"
+    write_ini_file(data, config_file)
+    with pytest.raises(ValueError, match='Missing required config sections'):
+        parse_ini_config(str(config_file), required_sections=['section1', 'section2'])
 
-def test_parse_ini_config_schema_validator():
+def test_parse_ini_config_schema_validator(tmp_path):
     """
     Test case 3: Custom schema validator raises ValueError
     """
@@ -43,9 +37,7 @@ def test_parse_ini_config_schema_validator():
     def schema(cfg):
         if 'section2' not in cfg:
             raise ValueError('section2 required')
-    with tempfile.NamedTemporaryFile('w+', delete=False, suffix='.ini') as tf:
-        write_ini_file(data, tf.name)
-        tf.close()
-        with pytest.raises(ValueError, match='section2 required'):
-            parse_ini_config(tf.name, schema_validator=schema)
-    os.remove(tf.name)
+    config_file = tmp_path / "config.ini"
+    write_ini_file(data, config_file)
+    with pytest.raises(ValueError, match='section2 required'):
+        parse_ini_config(str(config_file), schema_validator=schema)

--- a/pytest/unit/env_config_functions/test_parse_yaml_config.py
+++ b/pytest/unit/env_config_functions/test_parse_yaml_config.py
@@ -1,6 +1,4 @@
 import pytest
-import tempfile
-import os
 import yaml
 from env_config_functions.parse_yaml_config import parse_yaml_config
 
@@ -8,31 +6,27 @@ def write_yaml_file(data, path):
     with open(path, 'w') as f:
         yaml.safe_dump(data, f)
 
-def test_parse_yaml_config_basic():
+def test_parse_yaml_config_basic(tmp_path):
     """
     Test case 1: Basic YAML config loads as dict
     """
     data = {'a': 1, 'b': {'c': 2}}
-    with tempfile.NamedTemporaryFile('w+', delete=False, suffix='.yaml') as tf:
-        write_yaml_file(data, tf.name)
-        tf.close()
-        config = parse_yaml_config(tf.name)
-        assert config == data
-    os.remove(tf.name)
+    config_file = tmp_path / "config.yaml"
+    write_yaml_file(data, config_file)
+    config = parse_yaml_config(str(config_file))
+    assert config == data
 
-def test_parse_yaml_config_required_keys():
+def test_parse_yaml_config_required_keys(tmp_path):
     """
     Test case 2: Missing required keys raises ValueError
     """
     data = {'a': 1}
-    with tempfile.NamedTemporaryFile('w+', delete=False, suffix='.yaml') as tf:
-        write_yaml_file(data, tf.name)
-        tf.close()
-        with pytest.raises(ValueError, match='Missing required config keys'):
-            parse_yaml_config(tf.name, required_keys=['a', 'b'])
-    os.remove(tf.name)
+    config_file = tmp_path / "config.yaml"
+    write_yaml_file(data, config_file)
+    with pytest.raises(ValueError, match='Missing required config keys'):
+        parse_yaml_config(str(config_file), required_keys=['a', 'b'])
 
-def test_parse_yaml_config_schema_validator():
+def test_parse_yaml_config_schema_validator(tmp_path):
     """
     Test case 3: Custom schema validator raises ValueError
     """
@@ -40,32 +34,26 @@ def test_parse_yaml_config_schema_validator():
     def schema(cfg):
         if 'b' not in cfg:
             raise ValueError('b required')
-    with tempfile.NamedTemporaryFile('w+', delete=False, suffix='.yaml') as tf:
-        write_yaml_file(data, tf.name)
-        tf.close()
-        with pytest.raises(ValueError, match='b required'):
-            parse_yaml_config(tf.name, schema_validator=schema)
-    os.remove(tf.name)
+    config_file = tmp_path / "config.yaml"
+    write_yaml_file(data, config_file)
+    with pytest.raises(ValueError, match='b required'):
+        parse_yaml_config(str(config_file), schema_validator=schema)
 
-def test_parse_yaml_config_invalid_yaml():
+def test_parse_yaml_config_invalid_yaml(tmp_path):
     """
     Test case 4: Invalid YAML raises yaml.YAMLError
     """
-    with tempfile.NamedTemporaryFile('w+', delete=False, suffix='.yaml') as tf:
-        tf.write('a: 1\nb: [1, 2\n')  # malformed YAML
-        tf.close()
-        with pytest.raises(yaml.YAMLError):
-            parse_yaml_config(tf.name)
-    os.remove(tf.name)
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text('a: 1\nb: [1, 2\n')  # malformed YAML
+    with pytest.raises(yaml.YAMLError):
+        parse_yaml_config(str(config_file))
 
-def test_parse_yaml_config_not_dict():
+def test_parse_yaml_config_not_dict(tmp_path):
     """
     Test case 5: YAML that is not a dict raises ValueError
     """
     data = [1, 2, 3]
-    with tempfile.NamedTemporaryFile('w+', delete=False, suffix='.yaml') as tf:
-        write_yaml_file(data, tf.name)
-        tf.close()
-        with pytest.raises(ValueError, match='must be a dictionary'):
-            parse_yaml_config(tf.name)
-    os.remove(tf.name)
+    config_file = tmp_path / "config.yaml"
+    write_yaml_file(data, config_file)
+    with pytest.raises(ValueError, match='must be a dictionary'):
+        parse_yaml_config(str(config_file))


### PR DESCRIPTION
## Summary
- refactor env config tests to use pytest's `tmp_path` fixture instead of `NamedTemporaryFile`
- write config data directly to paths like `tmp_path / "config.yaml"`
- drop manual `os.remove` cleanup in tests

## Testing
- `pytest pytest/unit/env_config_functions`


------
https://chatgpt.com/codex/tasks/task_e_68acad102a84832593eb5010505e5cfd