### PR TITLE
Allow safe_json_dump to return default

### DIFF
--- a/json_functions/safe_json_dump.py
+++ b/json_functions/safe_json_dump.py
@@ -1,7 +1,15 @@
 import json
-from typing import Any, Optional, Type
+from typing import Any, Optional, Type, TypeVar
 
-def safe_json_dump(obj: Any, default: Optional[Any] = None, encoder: Optional[Type[json.JSONEncoder]] = None, **kwargs) -> str:
+T = TypeVar("T")
+
+
+def safe_json_dump(
+    obj: Any,
+    default: Optional[T] = None,
+    encoder: Optional[Type[json.JSONEncoder]] = None,
+    **kwargs,
+) -> str | T:
     """
     Safely dump an object to a JSON string, returning a default value on error.
     
@@ -18,8 +26,9 @@ def safe_json_dump(obj: Any, default: Optional[Any] = None, encoder: Optional[Ty
         
     Returns
     -------
-    str
-        The JSON string, or default if serialization fails.
+    str or T
+        The JSON string, or the provided default value (which may be any type) if
+        serialization fails.
         
     Examples
     --------

--- a/pytest/unit/json_functions/test_safe_json_dump.py
+++ b/pytest/unit/json_functions/test_safe_json_dump.py
@@ -22,9 +22,22 @@ def test_safe_json_dump_invalid():
     result = safe_json_dump(obj, default=None)
     assert result is None
 
+
+def test_safe_json_dump_non_string_default():
+    """
+    Test case 3: Unserializable object returns a non-string default value.
+    """
+    class NotSerializable:
+        pass
+
+    obj = NotSerializable()
+    default = {"error": "failed"}
+    result = safe_json_dump(obj, default=default)
+    assert result is default
+
 def test_safe_json_dump_custom_encoder():
     """
-    Test case 3: Custom encoder is used for special types.
+    Test case 4: Custom encoder is used for special types.
     """
     class MyEncoder(json.JSONEncoder):
         def default(self, obj):


### PR DESCRIPTION
## Summary
- allow `safe_json_dump` to return any default type via a generic return annotation
- cover non-string defaults in `safe_json_dump` tests

## Testing
- `pytest pytest/unit/json_functions/test_safe_json_dump.py`
- `pytest` *(fails: import file mismatch and env config function errors)*

------
https://chatgpt.com/codex/tasks/task_e_68acb1f3d34883258f0639cf430ee9fe