### PR TITLE
Handle directory access errors in get_paths_in_directory

### DIFF
--- a/file_functions/get_paths_in_directory.py
+++ b/file_functions/get_paths_in_directory.py
@@ -29,6 +29,10 @@ def get_paths_in_directory(directory: str, type_: str) -> list[str]:
     ------
     ValueError
         If the `type_` parameter is not one of the valid options ('files', 'directories', 'all').
+    FileNotFoundError
+        If the specified directory does not exist.
+    PermissionError
+        If the directory cannot be accessed due to insufficient permissions.
     """
     if_type: Callable[[str], bool]
     if type_ == "files":
@@ -40,7 +44,12 @@ def get_paths_in_directory(directory: str, type_: str) -> list[str]:
     else:
         raise ValueError(f"Invalid type: {type_}")
 
-    all_items: list[str] = os.listdir(directory)
+    try:
+        all_items: list[str] = os.listdir(directory)
+    except OSError as exc:
+        raise type(exc)(
+            f"Unable to access directory '{directory}': {exc}"
+        ) from exc
     file_paths: list[str] = [
         os.path.join(directory, item)
         for item in all_items

--- a/pytest/unit/file_functions/test_get_paths_in_directory.py
+++ b/pytest/unit/file_functions/test_get_paths_in_directory.py
@@ -122,5 +122,21 @@ def test_get_paths_in_directory_nonexistent_directory(tmp_path: Path) -> None:
     Test case 10: Test that providing a non-existent directory raises an error.
     """
     missing_dir: str = os.path.join(str(tmp_path), "missing")
-    with pytest.raises(FileNotFoundError):
+    with pytest.raises(FileNotFoundError, match="Unable to access directory"):
         get_paths_in_directory(missing_dir, "files")
+
+
+def test_get_paths_in_directory_permission_denied(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    Test case 11: Test that permission errors are surfaced with a clear message.
+    """
+
+    def mock_listdir(_path: str) -> list[str]:
+        raise PermissionError("mocked error")
+
+    monkeypatch.setattr(os, "listdir", mock_listdir)
+
+    with pytest.raises(PermissionError, match="Unable to access directory"):
+        get_paths_in_directory(str(tmp_path), "files")


### PR DESCRIPTION
## Summary
- document and handle directory access errors in `get_paths_in_directory`
- cover nonexistent and permission-denied directories in tests

## Testing
- `pytest pytest/unit/file_functions/test_get_paths_in_directory.py`


------
https://chatgpt.com/codex/tasks/task_e_68acb1f57d0c83258cd6ca7e94bfeda8