### PR TITLE
Reduce rate limit test wait times

### DIFF
--- a/pytest/unit/asyncio_functions/test_async_rate_limited.py
+++ b/pytest/unit/asyncio_functions/test_async_rate_limited.py
@@ -13,20 +13,20 @@ async def echo(value: int) -> int:
 async def test_async_rate_limited_success() -> None:
     """Test processing items with a rate limit."""
     start = time.monotonic()
-    result = await async_rate_limited(echo, [1, 2, 3], max_calls=2, period=1.0)
+    result = await async_rate_limited(echo, [1, 2, 3], max_calls=2, period=0.1)
     elapsed = time.monotonic() - start
     assert result == [1, 2, 3]
-    assert elapsed >= 1.0
+    assert elapsed >= 0.1
 
 
 @pytest.mark.asyncio
 async def test_async_rate_limited_tuple() -> None:
     """Test processing a tuple of items."""
     start = time.monotonic()
-    result = await async_rate_limited(echo, (1, 2, 3), max_calls=2, period=1.0)
+    result = await async_rate_limited(echo, (1, 2, 3), max_calls=2, period=0.1)
     elapsed = time.monotonic() - start
     assert result == [1, 2, 3]
-    assert elapsed >= 1.0
+    assert elapsed >= 0.1
 
 
 def generate_numbers():
@@ -38,16 +38,16 @@ def generate_numbers():
 async def test_async_rate_limited_generator() -> None:
     """Test processing items from a generator."""
     start = time.monotonic()
-    result = await async_rate_limited(echo, generate_numbers(), max_calls=2, period=1.0)
+    result = await async_rate_limited(echo, generate_numbers(), max_calls=2, period=0.1)
     elapsed = time.monotonic() - start
     assert result == [0, 1, 2]
-    assert elapsed >= 1.0
+    assert elapsed >= 0.1
 
 
 @pytest.mark.asyncio
 async def test_async_rate_limited_invalid_params() -> None:
     """Test invalid parameters raise ValueError."""
     with pytest.raises(ValueError):
-        await async_rate_limited(echo, [1], max_calls=0, period=1.0)
+        await async_rate_limited(echo, [1], max_calls=0, period=0.1)
     with pytest.raises(ValueError):
         await async_rate_limited(echo, [1], max_calls=1, period=0)


### PR DESCRIPTION
## Summary
- shorten async rate-limited tests by using a 0.1s period

## Testing
- `pytest` *(fails: import file mismatch in mathematical_functions/statistics tests)*

------
https://chatgpt.com/codex/tasks/task_e_68acb4db1228832585cc69a95cb1c3dd