### PR TITLE
Guard against negative truncation length

### DIFF
--- a/pytest/unit/strings_utility/test_truncate_string.py
+++ b/pytest/unit/strings_utility/test_truncate_string.py
@@ -90,7 +90,8 @@ def test_truncate_string_negative_length() -> None:
     """
     Test case 11: Test the truncate_string function with a negative length.
     """
-    assert truncate_string("hello", -3) == "he", "Failed on negative length"
+    with pytest.raises(ValueError, match="length must be non-negative"):
+        truncate_string("hello", -3)
 
 
 def test_truncate_string_invalid_string_type() -> None:

--- a/strings_utility/truncate_string.py
+++ b/strings_utility/truncate_string.py
@@ -37,6 +37,9 @@ def truncate_string(s: str, length: int) -> str:
     if not isinstance(length, int):
         raise TypeError("The length must be an integer.")
 
+    if length < 0:
+        raise ValueError("length must be non-negative")
+
     return s[:length]
 
 


### PR DESCRIPTION
## Summary
- prevent `truncate_string` from accepting negative lengths
- update tests to require ValueError when length is negative

## Testing
- `pytest`
- `pytest pytest/unit/strings_utility/test_truncate_string.py`


------
https://chatgpt.com/codex/tasks/task_e_68adef39fe988325b114d211d0715528