### PR TITLE
Handle URLError in upload_file

### DIFF
--- a/http_functions/upload_file.py
+++ b/http_functions/upload_file.py
@@ -2,6 +2,7 @@
 
 import urllib.request
 import urllib.parse
+from urllib.error import HTTPError, URLError
 from pathlib import Path
 from typing import Optional, Dict, Any
 import mimetypes
@@ -40,8 +41,6 @@ def upload_file(url: str, file_path: str, field_name: str = "file",
         If URL or file_path is invalid.
     FileNotFoundError
         If the file doesn't exist.
-    urllib.error.URLError
-        If the upload fails.
         
     Examples
     --------
@@ -119,10 +118,17 @@ def upload_file(url: str, file_path: str, field_name: str = "file",
                 'headers': dict(response.headers),
                 'success': True
             }
-    except urllib.error.HTTPError as e:
+    except HTTPError as e:
         return {
             'status_code': e.code,
             'content': e.read().decode('utf-8') if e.fp else '',
             'headers': dict(e.headers) if e.headers else {},
+            'success': False
+        }
+    except URLError as e:
+        return {
+            'status_code': None,
+            'content': str(e.reason),
+            'headers': {},
             'success': False
         }

--- a/pytest/unit/http_functions/test_upload_file.py
+++ b/pytest/unit/http_functions/test_upload_file.py
@@ -251,3 +251,21 @@ def test_upload_file_http_error(mock_guess_type, mock_urlopen, mock_file_open, m
     assert result['content'] == '{"error": "invalid file"}'
     assert result['success'] is False
     assert result['headers'] == {'Content-Type': 'application/json'}
+
+
+@patch('pathlib.Path.exists', return_value=True)
+@patch('pathlib.Path.is_file', return_value=True)
+@patch('builtins.open', new_callable=mock_open, read_data=b'test content')
+@patch('urllib.request.urlopen')
+@patch('mimetypes.guess_type', return_value=('text/plain', None))
+def test_upload_file_url_error(mock_guess_type, mock_urlopen, mock_file_open, mock_is_file, mock_exists):
+    """Test case 17: Test file upload when request fails returns error details."""
+    mock_urlopen.side_effect = urllib.error.URLError('Connection failed')
+
+    with patch('pathlib.Path.name', 'test.txt'):
+        result = upload_file('https://example.com/upload', '/tmp/test.txt')
+
+    assert result['status_code'] is None
+    assert result['success'] is False
+    assert result['headers'] == {}
+    assert result['content'] == 'Connection failed'


### PR DESCRIPTION
## Summary
- extend `upload_file` to import and handle both `HTTPError` and `URLError`
- add regression test ensuring `URLError` yields structured failure response

## Testing
- `pytest --import-mode=importlib -q` *(fails: 190 failed, 1712 passed, 6 warnings)*
- `pytest pytest/unit/http_functions/test_upload_file.py::test_upload_file_url_error -q`


------
https://chatgpt.com/codex/tasks/task_e_68adef4920a88325b026efb45f642377