### PR TITLE
Add pytz dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "numpy==2.3.2",
     "aiohttp==3.12.15",
     "pandas==2.3.1",
+    "pytz==2024.2",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- add pytz to project dependencies

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'yaml'; import file mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68af4bb68b1483259d89cfc9fe3fceae