### PR TITLE
Add LICENSE file reference in pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "python_utils"
 version = "0.1.0"
+license = {file = "LICENSE"}
 requires-python = ">=3.10"
 dependencies = [
     "cramjam==2.11.0",


### PR DESCRIPTION
## Summary
- include LICENSE file in project metadata so packaging tools pick up GPLv3 license

## Testing
- `python -m build`
- `twine check dist/*`
- `pytest` *(fails: import file mismatch: imported module 'test_random_floats' has this __file__ attribute: /workspace/python-utils/pytest/unit/mathematical_functions/random/test_random_floats.py which is not the same as the test file we want to collect: /workspace/python-utils/pytest/unit/mathematical_functions/statistics/test_random_floats.py)*

------
https://chatgpt.com/codex/tasks/task_e_68af4bb32e5083258efbf0927ae04664