### PR TITLE
Update linux docstrings to new typing style

### DIFF
--- a/linux_functions/get_cpu_info.py
+++ b/linux_functions/get_cpu_info.py
@@ -18,7 +18,7 @@ def get_cpu_info(interval: float = 0.1) -> dict[str, int | float | list[float]]:
 
     Returns
     -------
-    Dict[str, Union[int, float, List[float]]]
+    dict[str, int | float | list[float]]
         Dictionary containing CPU information including count, usage, and frequencies.
 
     Examples

--- a/linux_functions/get_disk_usage.py
+++ b/linux_functions/get_disk_usage.py
@@ -17,7 +17,7 @@ def get_disk_usage(path: str = '/') -> dict[str, int | float]:
 
     Returns
     -------
-    Dict[str, Union[int, float]]
+    dict[str, int | float]
         Dictionary containing disk usage information in bytes and percentage.
 
     Raises

--- a/linux_functions/get_network_interfaces.py
+++ b/linux_functions/get_network_interfaces.py
@@ -12,7 +12,7 @@ def get_network_interfaces() -> dict[str, list[dict[str, Any]]]:
 
     Returns
     -------
-    Dict[str, List[Dict[str, Any]]]
+    dict[str, list[dict[str, Any]]]
         Dictionary mapping interface names to their address information.
 
     Examples

--- a/linux_functions/list_directories.py
+++ b/linux_functions/list_directories.py
@@ -18,7 +18,7 @@ def list_directories(directory_path: str, include_hidden: bool = False) -> list[
 
     Returns
     -------
-    List[str]
+    list[str]
         List of directory names.
 
     Raises

--- a/linux_functions/list_files.py
+++ b/linux_functions/list_files.py
@@ -18,7 +18,7 @@ def list_files(directory_path: str, include_hidden: bool = False) -> list[str]:
 
     Returns
     -------
-    List[str]
+    list[str]
         List of file names in the directory.
 
     Raises


### PR DESCRIPTION
## Summary
- replace deprecated typing aliases with builtin generics in linux function docstrings

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'file_functions.file_operations.write_to_file')*

------
https://chatgpt.com/codex/tasks/task_e_68c18e57d2c883258ee2f0027f4bce70